### PR TITLE
Fixed cover off message for VMB1BL/VMB2BL

### DIFF
--- a/velbusaio/messages/cover_off.py
+++ b/velbusaio/messages/cover_off.py
@@ -104,7 +104,7 @@ class CoverOffMessage2(Message):
         else:
             tmp = 0x0C
 
-        return bytes([COMMAND_CODE, tmp]) + struct.pack(">L", self.delay_time)[-3:]
+        return bytes([COMMAND_CODE, tmp])
 
 
 register_command(COMMAND_CODE, CoverOffMessage2, "VMB1BL")


### PR DESCRIPTION
Result of debugging why the stop button doesn't function in my HomeAssistant setup. It seems the CoverOffMessage2 also sends the delay-bytes, which are not supported on this command.

Was already fixed in python-velbus: https://github.com/thomasdelaet/python-velbus/pull/73