### PR TITLE
Fix negative temperatures

### DIFF
--- a/velbusaio/messages/cover_off.py
+++ b/velbusaio/messages/cover_off.py
@@ -104,7 +104,7 @@ class CoverOffMessage2(Message):
         else:
             tmp = 0x0C
 
-        return bytes([COMMAND_CODE, tmp]) + struct.pack(">L", self.delay_time)[-3:]
+        return bytes([COMMAND_CODE, tmp])
 
 
 register_command(COMMAND_CODE, CoverOffMessage2, "VMB1BL")

--- a/velbusaio/messages/sensor_temperature.py
+++ b/velbusaio/messages/sensor_temperature.py
@@ -43,15 +43,15 @@ class SensorTemperatureMessage(Message):
         self.needs_no_rtr(rtr)
         self.needs_data(data, 6)
         self.set_attributes(priority, address, rtr)
-        if (((data[0] << 8) | data[1]) >> 15):
+        if ((data[0] << 8) | data[1]) >> 15:
             self.cur = -127 + (((data[0] << 8) | data[1]) / 32 * 0.0625)
         else:
             self.cur = (((data[0] << 8) | data[1]) / 32) * 0.0625
-        if (((data[2] << 8) | data[3]) >> 15):
+        if ((data[2] << 8) | data[3]) >> 15:
             self.min = -127 + (((data[2] << 8) | data[3]) / 32 * 0.0625)
         else:
             self.min = (((data[2] << 8) | data[3]) / 32) * 0.0625
-        if (((data[4] << 8) | data[5]) >> 15):
+        if ((data[4] << 8) | data[5]) >> 15:
             self.max = -127 + (((data[4] << 8) | data[5]) / 32 * 0.0625)
         else:
             self.max = (((data[4] << 8) | data[5]) / 32) * 0.0625

--- a/velbusaio/messages/sensor_temperature.py
+++ b/velbusaio/messages/sensor_temperature.py
@@ -43,9 +43,18 @@ class SensorTemperatureMessage(Message):
         self.needs_no_rtr(rtr)
         self.needs_data(data, 6)
         self.set_attributes(priority, address, rtr)
-        self.cur = (((data[0] << 8) | data[1]) / 32) * 0.0625
-        self.min = (((data[2] << 8) | data[3]) / 32) * 0.0625
-        self.max = (((data[4] << 8) | data[5]) / 32) * 0.0625
+        if (((data[0] << 8) | data[1]) >> 15):
+            self.cur = -127 + (((data[0] << 8) | data[1]) / 32 * 0.0625)
+        else:
+            self.cur = (((data[0] << 8) | data[1]) / 32) * 0.0625
+        if (((data[2] << 8) | data[3]) >> 15):
+            self.min = -127 + (((data[2] << 8) | data[3]) / 32 * 0.0625)
+        else:
+            self.min = (((data[2] << 8) | data[3]) / 32) * 0.0625
+        if (((data[4] << 8) | data[5]) >> 15):
+            self.max = -127 + (((data[4] << 8) | data[5]) / 32 * 0.0625)
+        else:
+            self.max = (((data[4] << 8) | data[5]) / 32) * 0.0625
 
     def to_json(self):
         """


### PR DESCRIPTION
With outside temperatures going below 0 °C some weeks ago, I noticed my VMBPIRO reporting negative temperatures as 127°C.
The proposed fix takes into account the sign-bit and adds the proper offset of -127.

Was already fixed in: https://github.com/thomasdelaet/python-velbus/pull/77/

Also fixes: https://github.com/home-assistant/core/issues/61238