### PR TITLE
Fix blind position reporting

### DIFF
--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -201,6 +201,15 @@ class Blind(Channel):
     def get_state(self) -> str:
         return self._state
 
+    def is_opening(self) -> bool:
+        return self._state == 0x01
+
+    def is_closing(self) -> bool:
+        return self._state == 0x02
+
+    def is_stopped(self) -> bool:
+        return self._state == 0x00
+
     def is_closed(self) -> bool | None:
         """Report if the blind is fully closed."""
         if self._position is None:

--- a/velbusaio/messages/blind_status.py
+++ b/velbusaio/messages/blind_status.py
@@ -107,7 +107,7 @@ class BlindStatusMessage(Message):
         self.channel = self.byte_to_channel(tmp)
         self.timeout = data[1]  # Omzetter seconden ????
         # 2 bits per channel used
-        self.status = data[2] >> ((self.channel - 1) * 2)
+        self.status = (data[2] >> ((self.channel - 1) * 2)) & 0x03
 
     def to_json(self):
         """

--- a/velbusaio/messages/blind_status.py
+++ b/velbusaio/messages/blind_status.py
@@ -49,17 +49,14 @@ class BlindStatusNgMessage(Message):
         json_dict["status"] = DSTATUS[self.status]
         return json.dumps(json_dict)
 
-    def is_up(self):
-        """
-        :return: bool
-        """
+    def is_moving_up(self) -> bool:
         return self.status == 0x01
 
-    def is_down(self):
-        """
-        :return: bool
-        """
+    def is_moving_down(self) -> bool:
         return self.status == 0x02
+
+    def is_stopped(self) -> bool:
+        return self.status == 0x00
 
     def data_to_binary(self):
         """
@@ -119,17 +116,14 @@ class BlindStatusMessage(Message):
         json_dict["status"] = DSTATUS[self.status]
         return json.dumps(json_dict)
 
-    def is_up(self):
-        """
-        :return: bool
-        """
+    def is_moving_up(self) -> bool:
         return self.status == 0x01
 
-    def is_down(self):
-        """
-        :return: bool
-        """
+    def is_moving_down(self) -> bool:
         return self.status == 0x02
+
+    def is_stopped(self) -> bool:
+        return self.status == 0x00
 
 
 register_command(COMMAND_CODE, BlindStatusNgMessage, "VMB1BLE")


### PR DESCRIPTION
This PR fixes some issues with the Blind implementation:
* (minor) correct decoding of the status bits for old VMB2BL modules
* rename methods of BlindStatusMessage to better reflect their meaning: `state` refers to the movement of the blind, not the position. I was confused by this as well when I started working on Velbus.
* Determine is_closed() based on position (if available), not on movement.

This should fix #44 and fix #31.