### PR TITLE
Support long module names

### DIFF
--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
 import pytest
 
+import velbusaio.command_registry
 from velbusaio.command_registry import CommandRegistry, register_command
 
 
-def test_defaults():
+@pytest.fixture()
+def own_command_registry():
+    """
+    Ensure a clean, empty commandRegistry; even when modules are loaded as part of other tests
+    """
+    orig_command_registry = velbusaio.command_registry.commandRegistry
+    velbusaio.command_registry.commandRegistry = CommandRegistry({})
+    yield
+    velbusaio.command_registry.commandRegistry = orig_command_registry
+
+
+def test_defaults(own_command_registry):
     # insert some data
     register_command(1, "testclass")
     register_command(2, "testclass2")

--- a/tests/test_module_name.py
+++ b/tests/test_module_name.py
@@ -1,0 +1,41 @@
+import logging
+
+import pytest
+
+from velbusaio.handler import PacketHandler
+from velbusaio.messages import MemoryDataMessage
+from velbusaio.module import Module
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Temp. controller",
+        "Shorter name",
+    ],
+)
+async def test_module_name(name):
+    module_address = 1
+    module_type = 0x0E  # VMB1TC
+
+    memory = {}
+    for i in range(0, 16):
+        memory[0xF0 + i] = 0xFF
+    for i, c in enumerate(name):
+        memory[0xF0 + i] = ord(c)
+
+    ph = PacketHandler(None, None)
+    m = Module(
+        module_address, module_type, ph.pdata["ModuleTypes"][f"{module_type:02X}"]
+    )
+    m._log = logging.getLogger("velbus-module")
+
+    for addr, data in memory.items():
+        msg = MemoryDataMessage()
+        msg.high_address = addr >> 8
+        msg.low_address = addr & 0xFF
+        msg.data = data
+        await m._process_memory_data_message(msg)
+
+    assert m.get_name() == name

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -486,12 +486,13 @@ class Module:
         if "ModuleName" in mdata and isinstance(self._name, dict):
             # if self._name is a dict we are still loading
             # if its a string it was already complete
-            if message.data == 0xFF:
-                # modulename is complete
-                self._name = "".join(str(x) for x in self._name.values())
-            else:
-                char = mdata["ModuleName"].split(":")[0]
-                self._name[int(char)] = chr(message.data)
+            char_and_save = mdata["ModuleName"].split(":")
+            char = char_and_save[0]
+            self._name[int(char)] = chr(message.data)
+            if len(char_and_save) > 1 and char_and_save[1] == "Save":
+                self._name = "".join(
+                    str(x) for x in self._name.values() if x != chr(0xFF)
+                )
         elif "Match" in mdata:
             for chan, chan_data in handle_match(mdata["Match"], message.data).items():
                 data = chan_data.copy()


### PR DESCRIPTION
Hi,

I've run in to a bug when a module has a name of maximum length. The current code looks for 0xff (the filler-character) to determine the end of the module name. This works, as long as the module name is shorter than the maximum supported length.

When the name is the maximum length, such as the VMB1TC module that has a hard-coded name of `Temp. controller` (16 of 16 bytes long), the current code fails to detect the end of the Module Name. This in turn prevents the module from being marked "loaded".

This PR changes the parsing logic to rely on the "16:Save" marker from ModuleProtocol instead of the 0xff filler characters.

I've also added a test to test this. The test itself isn't very clean, but it covers this change.