### PR TITLE
Don't blindly update high-precision temperature with low-precision temp.

### DIFF
--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1,0 +1,54 @@
+import math
+import typing
+
+import pytest
+
+from velbusaio.channels import Temperature
+
+
+@pytest.fixture()
+def temperature_profile(request):
+    ramp_up = [20.0000 + n * 1 / 16 for n in range(0, 17)]
+    ramp_down = reversed(ramp_up)
+    return [*ramp_up, *ramp_down]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "precision",
+    [
+        1 / 2,
+        1 / 16,
+    ],
+)
+async def test_temperature_same_precision(
+    temperature_profile: typing.List[float],
+    precision: float,
+):
+    ch = Temperature(None, None, None, False, None, None)
+    for temp in temperature_profile:
+        temp_truncated_to_precision = math.floor(temp / precision) * precision
+        await ch.maybe_update_temperature(temp_truncated_to_precision, precision)
+        stored_temp = ch._cur
+        assert stored_temp <= temp < stored_temp + precision
+
+
+@pytest.mark.asyncio
+async def test_temperature_alternating_precision(
+    temperature_profile: typing.List[float],
+):
+    ch = Temperature(None, None, None, False, None, None)
+    for temp in temperature_profile:
+        for precision in [1 / 2, 1 / 64]:
+            temp_truncated_to_precision = math.floor(temp / precision) * precision
+            await ch.maybe_update_temperature(temp_truncated_to_precision, precision)
+
+            stored_temp = ch._cur
+            stored_temp_truncated_to_precision = (
+                math.floor(stored_temp / precision) * precision
+            )
+            assert (
+                stored_temp_truncated_to_precision
+                <= temp
+                < stored_temp_truncated_to_precision + precision
+            )

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -282,9 +282,11 @@ class Module:
             )
         elif isinstance(message, SensorTemperatureMessage):
             chan = self._translate_channel_name(self._data["TemperatureChannel"])
+            await self._channels[chan].maybe_update_temperature(
+                message.getCurTemp(), 1 / 64
+            )
             await self._channels[chan].update(
                 {
-                    "cur": message.getCurTemp(),
                     "min": message.getMinTemp(),
                     "max": message.getMaxTemp(),
                 }
@@ -295,11 +297,13 @@ class Module:
             if chan in self._channels:
                 await self._channels[chan].update(
                     {
-                        "cur": message.current_temp,
                         "target": message.target_temp,
                         "cmode": message.mode_str,
                         "cstatus": message.status_str,
                     }
+                )
+                await self._channels[chan].maybe_update_temperature(
+                    message.current_temp, 1 / 2
                 )
         elif isinstance(message, PushButtonStatusMessage):
             _update_buttons = False


### PR DESCRIPTION
When receiving a new low-precision temperature, either ignore it if the current stored (high-precision) value is still correct based on the new message. When temperature is going down, artificially increase precision to prevent jumps.

Relates to #50 