### PR TITLE
exclude "examples" from installing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ zip-safe  = false
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+exclude = ["tests", "tests.*", "examples"]


### PR DESCRIPTION
otherwise:

```
2023-03-01 22:18:20,911 gpep517 INFO Installation complete
>>> Source compiled.
>>> Test phase [not enabled]: dev-python/velbus-aio-2023.2.0

>>> Install dev-python/velbus-aio-2023.2.0 into /var/tmp/portage/dev-python/velbus-aio-2023.2.0/image
 * python3_10: running distutils-r1_run_phase distutils-r1_python_install
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.10/site-packages/examples
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/velbus-aio-2023.2.0::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
```