### PR TITLE
Add EdgeLit functions

### DIFF
--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -18,6 +18,7 @@ from velbusaio.const import (
     VOLUME_LITERS_HOUR,
 )
 from velbusaio.message import Message
+from velbusaio.messages.edge_set_color import SetEdgeColorMessage, CustomColorPriority
 from velbusaio.messages.module_status import PROGRAM_SELECTION
 
 if TYPE_CHECKING:
@@ -703,8 +704,42 @@ class EdgeLit(Channel):
     An EdgeLit channel
     """
 
-    # def get_categories(self):
-    #    return ["light"]
+    async def reset_color(self, left=True, top=True, right=True, bottom=True):
+        msg = SetEdgeColorMessage(self._address)
+        msg.apply_background_color = True
+        msg.color_idx = 0
+        msg.apply_to_left_edge = left
+        msg.apply_to_top_edge = top
+        msg.apply_to_right_edge = right
+        msg.apply_to_bottom_edge = bottom
+        msg.apply_to_all_pages = True
+        await self._writer(msg)
+
+    async def set_color(
+        self,
+        color_idx: int,
+        left=True,
+        top=True,
+        right=True,
+        bottom=True,
+        blinking=False,
+        priority=CustomColorPriority.LOW_PRIORITY,
+    ) -> None:
+        """
+        Send the turn off message
+        """
+
+        msg = SetEdgeColorMessage(self._address)
+        msg.apply_background_color = True
+        msg.background_blinking = blinking
+        msg.color_idx = color_idx
+        msg.apply_to_left_edge = left
+        msg.apply_to_top_edge = top
+        msg.apply_to_right_edge = right
+        msg.apply_to_bottom_edge = bottom
+        msg.apply_to_all_pages = True
+        msg.custom_color_priority = priority
+        await self._writer(msg)
 
 
 class Memo(Channel):

--- a/velbusaio/messages/edge_set_color.py
+++ b/velbusaio/messages/edge_set_color.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from velbusaio.command_registry import register
+from velbusaio.message import Message
+
+COMMAND_CODE = 0xD4
+
+
+class CustomColorPriority(IntEnum):
+    LOW_PRIORITY = 1
+    MID_PRIORITY = 2
+    HIGH_PRIORITY = 3
+
+
+@register(COMMAND_CODE, ["VMBEL1", "VMBEL2", "VMBEL4", "VMBELO"])
+class SetEdgeColorMessage(Message):
+    """
+    send by:
+    received by: VMBEL1, VMBEL2, VMBEL4, VMBELO
+    """
+
+    apply_background_color = False
+    apply_continuous_feedback_color = False
+    apply_slow_blinking_feedback_color = False
+    apply_fast_blinking_feedback_color = False
+    custom_color_palette = False
+
+    apply_to_left_edge = False
+    apply_to_top_edge = False
+    apply_to_right_edge = False
+    apply_to_bottom_edge = False
+
+    apply_to_page: int | None = None
+    apply_to_all_pages = False
+
+    background_blinking = False
+    custom_color_priority: CustomColorPriority | None = None
+
+    color_idx: int = 0
+
+    def populate(self, priority, address, rtr, data):
+        """
+        :return: None
+        """
+        self.needs_no_rtr(rtr)
+        self.set_attributes(priority, address, rtr)
+
+        self.apply_background_color = bool(data[0] & 0x01)
+        self.apply_continuous_feedback_color = bool(data[0] & 0x02)
+        self.apply_slow_blinking_feedback_color = bool(data[0] & 0x04)
+        self.apply_fast_blinking_feedback_color = bool(data[0] & 0x08)
+        self.custom_color_palette = bool(data[0] & 0x80)
+
+        self.apply_to_left_edge = bool(data[1] & 0x01)
+        self.apply_to_top_edge = bool(data[1] & 0x02)
+        self.apply_to_right_edge = bool(data[1] & 0x04)
+        self.apply_to_bottom_edge = bool(data[1] & 0x08)
+
+        page = (data[1] & 0b0111_0000) >> 4
+        if page > 0:
+            self.apply_to_page = page
+        self.apply_to_all_pages = bool(data[1] & 0x80)
+
+        self.background_blinking = bool(data[2] & 0x80)
+
+        custom_color_priority_value = data[2] & 0b0110_0000 >> 5
+        if custom_color_priority_value:
+            self.custom_color_priority = CustomColorPriority(
+                custom_color_priority_value
+            )
+
+        self.color_idx = data[2] & 0b0001_1111
+
+    def data_to_binary(self):
+        """
+        :return: bytes
+        """
+
+        byte_2 = (
+            self.apply_background_color * 0x01
+            + self.apply_continuous_feedback_color * 0x02
+            + self.apply_slow_blinking_feedback_color * 0x04
+            + self.apply_fast_blinking_feedback_color * 0x08
+            + self.custom_color_palette * 0x80
+        )
+
+        byte_3 = (
+            self.apply_to_left_edge * 0x01
+            + self.apply_to_top_edge * 0x02
+            + self.apply_to_right_edge * 0x04
+            + self.apply_to_bottom_edge * 0x08
+            + (((self.apply_to_page or 0) & 0xFFF) << 4)
+            + self.apply_to_all_pages * 0x80
+        )
+
+        byte_4 = (
+            (self.color_idx & 0xFFFF)
+            + (
+                (int(self.custom_color_priority) if self.custom_color_priority else 0)
+                << 5
+            )
+            + self.background_blinking * 0x80
+        )
+
+        return bytes(
+            [
+                COMMAND_CODE,
+                byte_2,
+                byte_3,
+                byte_4,
+            ]
+        )

--- a/velbusaio/messages/edge_set_custom_color.py
+++ b/velbusaio/messages/edge_set_custom_color.py
@@ -9,11 +9,11 @@ from velbusaio.message import Message
 COMMAND_CODE = 0xD4
 
 
-@register(COMMAND_CODE)
+@register(COMMAND_CODE, ["VMBEL1", "VMBEL2", "VMBEL4", "VMBELO"])
 class EdgeSetCustomColor(Message):
     """
     send by:
-    received by: VMB4RYLD
+    received by: VMBEL1, VMBEL2, VMBEL4, VMBELO
     """
 
     def __init__(self, address=None):


### PR DESCRIPTION
This PR adds the ability to set the edge colors on the VMBEL1, VMBEL2, VMBEL4, VMBELO modules. I only own a VMBELO module, so I could only test against that one.

The function parameters mirror the available configuration options ins VelbusLink:

![image](https://user-images.githubusercontent.com/2150060/229300089-0fb5cd33-842a-4293-9ffb-b0889d617980.png)

I used the following code to test:

```python
velbus = Velbus(connect_str)
await velbus.connect()

# get edge lit channel
edge_lit_chan : EdgeLit = None

for key, chan in (velbus.get_module(128).get_channels()).items():
    if isinstance(chan, EdgeLit):
        edge_lit_chan = chan
        break

print(edge_lit_chan)

from velbusaio.messages.edge_set_color import CustomColorPriority
await edge_lit_chan.set_color(20, priority=CustomColorPriority.HIGH_PRIORITY, blinking=True)

await asyncio.sleep(5)

await edge_lit_chan.reset_color()
await asyncio.sleep(5)
```

Note that I didn't use `commandRegistry.get_command(0xD4, ...` to retrieve the message class, as both `EdgeSetCustomColor` and `SetEdgeColorMessage` use the same `0xD4` command code. I guess that the module itself differentiates between both by looking at the length of the message? 🤔