### PR TITLE
Added support for getting the cool_mode (to switch HVAC mode)

### DIFF
--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -548,10 +548,10 @@ class Temperature(Channel):
 
     def get_climate_mode(self) -> str:
         return self._cstatus
-    
+
     def get_cool_mode(self) -> str:
         return self._cool_mode
-        
+
     async def set_temp(self, temp: float) -> None:
         cls = commandRegistry.get_command(0xE4, self._module.get_type())
         msg = cls(self._address)

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -548,7 +548,10 @@ class Temperature(Channel):
 
     def get_climate_mode(self) -> str:
         return self._cstatus
-
+    
+    def get_cool_mode(self) -> str:
+        return self._cool_mode
+        
     async def set_temp(self, temp: float) -> None:
         cls = commandRegistry.get_command(0xE4, self._module.get_type())
         msg = cls(self._address)

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -324,6 +324,7 @@ class Module:
                         "cmode": message.mode_str,
                         "cstatus": message.status_str,
                         "sleep_timer": message.sleep_timer,
+                        "cool_mode": message.cool_mode,
                     },
                 )
                 await self._channels[chan].maybe_update_temperature(


### PR DESCRIPTION
These are the two changes required to support the get_cool_mode function working. This is required to get the actual status of the thermostat (cool/heat) based on the 0xEA (Transmit the Sensor Status) message. And will be used in the HA module climate.py - the new module reports back the "cooling" mode in True/False (False being Heat mode)