### PR TITLE
added _coolmode = None

### DIFF
--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -548,10 +548,10 @@ class Temperature(Channel):
 
     def get_climate_mode(self) -> str:
         return self._cstatus
-    
+
     def get_cool_mode(self) -> str:
         return self._cool_mode
-        
+
     async def set_temp(self, temp: float) -> None:
         cls = commandRegistry.get_command(0xE4, self._module.get_type())
         msg = cls(self._address)

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -508,6 +508,7 @@ class Temperature(Channel):
     _max = None
     _min = None
     _target = 0
+    _coolmode = None
     _cmode = None
     _cstatus = None
     _thermostat = False

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -548,7 +548,10 @@ class Temperature(Channel):
 
     def get_climate_mode(self) -> str:
         return self._cstatus
-
+    
+    def get_cool_mode(self) -> str:
+        return self._cool_mode
+        
     async def set_temp(self, temp: float) -> None:
         cls = commandRegistry.get_command(0xE4, self._module.get_type())
         msg = cls(self._address)

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -324,6 +324,7 @@ class Module:
                         "cmode": message.mode_str,
                         "cstatus": message.status_str,
                         "sleep_timer": message.sleep_timer,
+                        "cool_mode": message.cool_mode,
                     },
                 )
                 await self._channels[chan].maybe_update_temperature(


### PR DESCRIPTION
To always have a value, the coolmode for thermostat has None now as default value - as this is used in Velbus/climate.py for switching between cool/heat mode