### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dependencies = [
     "pyserial>=3.5.0",
     "pyserial-asyncio_fast>=0.11",

--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -59,7 +59,11 @@ class PacketHandler:
             self.broadcast = json.loads(data)
         else:
             async with async_open(
-                str(importlib.resources.files().joinpath("module_spec/broadcast.json"))
+                str(
+                    importlib.resources.files(__name__.split(".")[0]).joinpath(
+                        "module_spec/broadcast.json"
+                    )
+                )
             ) as protocol_file:
                 self.broadcast = json.loads(await protocol_file.read())
 

--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -55,8 +55,11 @@ class PacketHandler:
 
     async def read_protocol_data(self):
         if sys.version_info >= (3, 13):
-            data = importlib.resources.read_text(__name__, "module_spec/broadcast.json")
-            self.broadcast = json.loads(data)
+            with importlib.resources.path(
+                __name__, "module_spec/broadcast.json"
+            ) as fspath:
+                async with async_open(fspath) as protocol_file:
+                    self.broadcast = json.loads(await protocol_file.read())
         else:
             async with async_open(
                 str(

--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -6,14 +6,15 @@ Velbus packet handler
 from __future__ import annotations
 
 import asyncio
+import importlib.resources
 import json
 import logging
 import os
 import pathlib
 import pprint
+import sys
 from typing import TYPE_CHECKING, Awaitable, Callable
 
-import pkg_resources
 from aiofile import async_open
 
 from velbusaio.command_registry import commandRegistry
@@ -53,10 +54,14 @@ class PacketHandler:
         self._scan_delay_msec = 0
 
     async def read_protocol_data(self):
-        async with async_open(
-            pkg_resources.resource_filename(__name__, "module_spec/broadcast.json")
-        ) as protocol_file:
-            self.broadcast = json.loads(await protocol_file.read())
+        if sys.version_info >= (3, 13):
+            data = importlib.resources.read_text(__name__, "module_spec/broadcast.json")
+            self.broadcast = json.loads(data)
+        else:
+            async with async_open(
+                str(importlib.resources.files().joinpath("module_spec/broadcast.json"))
+            ) as protocol_file:
+                self.broadcast = json.loads(await protocol_file.read())
 
     def empty_cache(self) -> bool:
         if (

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -4,6 +4,7 @@ This represents a velbus module
 
 from __future__ import annotations
 
+import importlib.resources
 import json
 import logging
 import os
@@ -12,7 +13,6 @@ import struct
 import sys
 from typing import Awaitable, Callable
 
-import pkg_resources
 from aiofile import async_open
 
 from velbusaio.channels import (
@@ -166,12 +166,20 @@ class Module:
         self._log = logging.getLogger("velbus-module")
         # load the protocol data
         try:
-            async with async_open(
-                pkg_resources.resource_filename(
+            if sys.version_info >= (3, 13):
+                data = importlib.resources.read_text(
                     __name__, f"module_spec/{h2(self._type)}.json"
                 )
-            ) as protocol_file:
-                self._data = json.loads(await protocol_file.read())
+                self._data = json.loads(data)
+            else:
+                async with async_open(
+                    str(
+                        importlib.resources.files().joinpath(
+                            f"module_spec/{h2(self._type)}.json"
+                        )
+                    )
+                ) as protocol_file:
+                    self._data = json.loads(await protocol_file.read())
             self._log.debug(f"Module spec {h2(self._type)} loaded")
         except FileNotFoundError:
             self._log.warning(f"No module spec for {h2(self._type)}")

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -167,10 +167,11 @@ class Module:
         # load the protocol data
         try:
             if sys.version_info >= (3, 13):
-                data = importlib.resources.read_text(
+                with importlib.resources.path(
                     __name__, f"module_spec/{h2(self._type)}.json"
-                )
-                self._data = json.loads(data)
+                ) as fspath:
+                    async with async_open(fspath) as protocol_file:
+                        self._data = json.loads(await protocol_file.read())
             else:
                 async with async_open(
                     str(

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -174,7 +174,7 @@ class Module:
             else:
                 async with async_open(
                     str(
-                        importlib.resources.files().joinpath(
+                        importlib.resources.files(__name__.split(".")[0]).joinpath(
                             f"module_spec/{h2(self._type)}.json"
                         )
                     )


### PR DESCRIPTION
`pkg_resources` is deprecated. Replace it with `importlib.resources`.
https://docs.python.org/3/library/importlib.resources.html