### PR TITLE
Expose private address in a getter for module.py

### DIFF
--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -139,7 +139,7 @@ class PacketHandler:
                 if module is not None:
                     try:
                         self._log.debug(
-                            f"Module {module._address} detected: start loading"
+                            f"Module {module.get_address()} detected: start loading"
                         )
                         await asyncio.wait_for(
                             module.load(from_cache=True),

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -243,6 +243,9 @@ class Module:
             d["channels"][num] = chan.to_cache()
         return d
 
+    def get_address(self) -> int:
+        return self._address
+
     def get_addresses(self) -> list:
         """
         Get all addresses for this module


### PR DESCRIPTION
small nitpick where we use the protected field module._address in logging.
Question: or should we always use the get_addresses? I don't get in which case a module has multiple addresses, and when it is used?