### PR TITLE
Infinite loop in sequential scan

### DIFF
--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -189,9 +189,9 @@ class PacketHandler:
                     self._typeResponseReceived.set()
                 else:
                     self._log.debug(
-                        f"Unexpected module type message module address {address}, Velbuslink scan?"
+                        f"Unexpected module type message for module scan {self._modulescan_address} from module address {address}, Velbuslink scan?"
                     )
-                    self._modulescan_address = address - 1
+                    self._modulescan_address = address - 1 #TODO PJ: This seems bad!
 
             self._typeResponseReceived.set()
 

--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -191,9 +191,6 @@ class PacketHandler:
                     self._log.debug(
                         f"Unexpected module type message for module scan {self._modulescan_address} from module address {address}, Velbuslink scan?"
                     )
-                    self._modulescan_address = address - 1 #TODO PJ: This seems bad!
-
-            self._typeResponseReceived.set()
 
         # handle module subtype response message
         elif command_value in (0xB0, 0xA7, 0xA6) and not self._scan_complete:

--- a/velbusaio/message.py
+++ b/velbusaio/message.py
@@ -4,6 +4,7 @@ The velbus abstract message class
 
 from __future__ import annotations
 
+import enum
 import json
 
 from velbusaio.const import PRIORITY_FIRMWARE, PRIORITY_HIGH, PRIORITY_LOW
@@ -65,8 +66,13 @@ class Message:
                 continue
             if callable(getattr(self, key)) or key.startswith("__"):
                 del me[key]
-            if isinstance(me[key], (bytes, bytearray)):
+            if isinstance(me[key], (bytes, bytearray, enum.Enum)):
                 me[key] = str(me[key])
+            else:
+                try:
+                    json.dumps(me[key])  # Test if the value is JSON serializable
+                except (TypeError, ValueError):
+                    me[key] = str(me[key])  # Convert non-serializable objects to string
         return me
 
     def to_json(self) -> str:


### PR DESCRIPTION
Alternative fix for the infinite loop scan in scenario of #146 
In this case we'll ignore unexpected module type responses, and keep waiting for the expected response.

@sidlgor @cereal2nd I still believe #134 is a more stable implementation of the scan, as it doesn't depend on being the only thing scanning on the bus. However, as that is a bigger adaptation, this fix might be merged sooner.

This fix is tested on my setup and has proven to work.