### PR TITLE
Fix return in finally

### DIFF
--- a/velbusaio/vlp_reader.py
+++ b/velbusaio/vlp_reader.py
@@ -215,8 +215,7 @@ class vlpModule:
         except UnicodeDecodeError as e:
             self._log.error(f"  => UnicodeDecodeError: {e}")
             name = byte_data
-        finally:
-            return name
+        return name
 
     async def _load_module_spec(self) -> None:
         self._log.debug(f" => Load module spec for {self._type_id}")


### PR DESCRIPTION
Python 3.14 emits a SyntaxWarning if a `return` is used in a `finally` block.
```py
  /.../site-packages/velbusaio/vlp_reader.py:219: SyntaxWarning: 'return' in a 'finally' block
    return name
```