### PR TITLE
Fix setting subdevice state from cache

### DIFF
--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -620,7 +620,7 @@ class Module:
             for num, chan in cache["channels"].items():
                 self._channels[int(num)]._name = chan["name"]
                 if "subdevice" in chan:
-                    self._channels[int(num)]._subDevice = chan["subdevice"] == "yes"
+                    self._channels[int(num)]._subDevice = chan["subdevice"]
                 else:
                     self._channels[int(num)]._subDevice = False
                 if "Unit" in chan:


### PR DESCRIPTION
Restore `subDevice` status from cache file into correct class property `_subDevice ` of channel.
This removes the orphen `sub_device` property at any channel at a downloaded diagnostics file in Home Assistant.