### PR TITLE
split setup VMB1RYS:0x41 and VMB1RYS-20:0x0d

### DIFF
--- a/velbusaio/command_registry.py
+++ b/velbusaio/command_registry.py
@@ -23,7 +23,7 @@ MODULE_DIRECTORY = {
     0x0A: "VMB8IR",
     0x0B: "VMB4PD",
     0x0C: "VMB1TS",
-    0x0D: "VMB1TH",
+    0x0D: "VMB1RYS-20",
     0x0E: "VMB1TC",
     0x0F: "VMB1LED",
     0x10: "VMB4RYLD",

--- a/velbusaio/messages/module_type.py
+++ b/velbusaio/messages/module_type.py
@@ -20,7 +20,6 @@ MODULES_WITHOUT_SERIAL = {
     0x08: "VMB4RY",
     0x09: "VMB2BL",
     0x0C: "VMB1TS",
-    0x0D: "VMB1TH",
     0x0E: "VMB1TC",
     0x0F: "VMB1LED",
     0x14: "VMBDME",
@@ -38,7 +37,6 @@ MODULES_WITHOUT_SERIAL = {
         "VMB8IR",
         "VMB4PD",
         "VMB1TS",
-        "VMB1TH",
         "VMB1TC",
         "VMB1LED",
         "VMB4RYLD",
@@ -146,6 +144,7 @@ class ModuleTypeMessage(Message):
         "VMB8IN-20",
         "VMB8DC-20",
         "VMB2DC-20",
+        "VMB1RYS-20",
     ],
 )
 class ModuleType2Message(Message):

--- a/velbusaio/messages/switch_relay_off.py
+++ b/velbusaio/messages/switch_relay_off.py
@@ -38,9 +38,7 @@ class SwitchRelayOffMessage(Message):
         return bytes([COMMAND_CODE, self.channels_to_byte(self.relay_channels)])
 
 
-@register(
-    COMMAND_CODE, ["VMB4RYLD-20", "VMB4RYNO-20", "VMB1RYS", "VMB1RYNO", "VMB1RYNOS"]
-)
+@register(COMMAND_CODE, ["VMB4RYLD-20", "VMB4RYNO-20", "VMB1RYS-20"])
 class SwitchRelayOffMessage20(SwitchRelayOffMessage):
     """Switch Relay Off Message for -20 series."""
 

--- a/velbusaio/messages/switch_relay_on.py
+++ b/velbusaio/messages/switch_relay_on.py
@@ -38,9 +38,7 @@ class SwitchRelayOnMessage(Message):
         return bytes([COMMAND_CODE, self.channels_to_byte(self.relay_channels)])
 
 
-@register(
-    COMMAND_CODE, ["VMB4RYLD-20", "VMB4RYNO-20", "VMB1RYS", "VMB1RYNO", "VMB1RYNOS"]
-)
+@register(COMMAND_CODE, ["VMB4RYLD-20", "VMB4RYNO-20", "VMB1RYS-20"])
 class SwitchRelayOnMessage20(SwitchRelayOnMessage):
     """Switch Relay On Message for -20 series."""
 

--- a/velbusaio/module_spec/0D.json
+++ b/velbusaio/module_spec/0D.json
@@ -1,3 +1,66 @@
 {
-  "Type": "VMB1TH"
+  "Channels": {
+    "01": {
+      "Editable": "yes",
+      "Name": "Relay",
+      "Type": "Relay",
+      "Subdevice": "yes"
+    },
+    "02": {
+      "Editable": "yes",
+      "Name": "Virtual relay 1",
+      "Type": "Relay",
+      "Subdevice": "no"
+    },
+    "03": {
+      "Editable": "yes",
+      "Name": "Virtual relay 2",
+      "Type": "Relay",
+      "Subdevice": "no"
+    },
+    "04": {
+      "Editable": "yes",
+      "Name": "Virtual relay 3",
+      "Type": "Relay",
+      "Subdevice": "no"
+    },
+    "05": {
+      "Editable": "yes",
+      "Name": "Virtual relay 4",
+      "Type": "Relay",
+      "Subdevice": "no"
+    },
+    "06": {
+      "Editable": "yes",
+      "Name": "Virtual relay 5",
+      "Type": "Relay",
+      "Subdevice": "no"
+    },
+    "07": {
+      "Editable": "yes",
+      "Name": "Virtual relay 6",
+      "Type": "Relay",
+      "Subdevice": "no"
+    },
+    "08": {
+      "Editable": "yes",
+      "Name": "Virtual relay 7",
+      "Type": "Relay",
+      "Subdevice": "no"
+    }
+  },
+  "Memory": {
+    "ModuleName": "07BC-07FB",
+    "Channels": {
+      "01": "0000-000F",
+      "02": "0014-0023",
+      "03": "0028-0037",
+      "04": "003C-004B",
+      "05": "0050-005F",
+      "06": "0064-0073",
+      "07": "0078-0087",
+      "08": "008C-009B"
+    }
+  },
+  "Type": "VMB1RYS-20"
 }


### PR DESCRIPTION
Use different id for VMB1RYS and VMB1RYS-20, as channel address encoding is different.
Remove update for non release devices VMB1RYNO-20 and VMB1RYNOS-20.
pytest and pre-commit OK