### PR TITLE
fix: ButtonCounter sensor category for VMB8IN-20 CounterValueMessage

### DIFF
--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -402,13 +402,13 @@ class ButtonCounter(Button):
 
     def get_categories(self) -> list[str]:
         """Return the categories for this channel."""
-        if self._counter:
+        if self._counter or self._power is not None or self._energy is not None:
             return ["sensor"]
         return ["binary_sensor", "button"]
 
     def is_counter_channel(self) -> bool:
         """Return if this channel is a counter channel."""
-        if self._counter:
+        if self._counter or self._power is not None or self._energy is not None:
             return True
         return False
 


### PR DESCRIPTION
**Full transparency: I created this PR with the help of Claude Code**

The VMB8IN-20 sends CounterValueMessage (0xA4) which sets _power and _energy on the channel, but never _counter. CounterStatusMessage (0xBE) which sets _counter is only registered for VMB7IN.

As a result, get_categories() and is_counter_channel() always fell back to binary_sensor/button for VMB8IN-20, causing the channel to be exposed as a binary sensor in Home Assistant with no energy data visible.

Fix: also return 'sensor' when _power or _energy is set, covering the VMB8IN-20 case where only CounterValueMessage is ever received.