### PR TITLE
Fix channel number translation for modules with ChannelNumbers.Name.Map

### DIFF
--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -967,14 +967,17 @@ class Module:
         # load the channel names
         if "channels" in cache:
             for num, chan in cache["channels"].items():
-                self._channels[int(num)].set_name(chan["name"])
+                chan_num = self._translate_channel_name(num)
+                if chan_num not in self._channels:
+                    continue
+                self._channels[chan_num].set_name(chan["name"])
                 if "subdevice" in chan:
-                    self._channels[int(num)].set_sub_device(chan["subdevice"])
+                    self._channels[chan_num].set_sub_device(chan["subdevice"])
                 else:
-                    self._channels[int(num)].set_sub_device(False)
+                    self._channels[chan_num].set_sub_device(False)
                 if "Unit" in chan:
-                    self._channels[int(num)].set_unit(chan["Unit"])
-                self._channels[int(num)].set_loaded(True)
+                    self._channels[chan_num].set_unit(chan["Unit"])
+                self._channels[chan_num].set_loaded(True)
         else:
             await self._request_channel_name()
         # load the module specific stuff
@@ -1254,9 +1257,10 @@ class Module:
                 )
                 continue
 
-            self._channels[int(chan)] = cls(
+            chan_num = self._translate_channel_name(chan)
+            self._channels[chan_num] = cls(
                 module=self,
-                num=int(chan),
+                num=chan_num,
                 name=chan_data["Name"],
                 nameEditable=edit,
                 subDevice=sub,
@@ -1267,9 +1271,9 @@ class Module:
                 if "Thermostat" in self._data or (
                     "ThermostatAddr" in self._data and self._data["ThermostatAddr"] != 0
                 ):
-                    await self._update_channel(int(chan), {"thermostat": True})
+                    await self._update_channel(chan_num, {"thermostat": True})
             if chan_data["Type"] == "Dimmer" and "sliderScale" in self._data:
-                self._channels[int(chan)].slider_scale = self._data["sliderScale"]
+                self._channels[chan_num].slider_scale = self._data["sliderScale"]
 
 
 class VmbDali(Module):


### PR DESCRIPTION
### Problem
Modules like `VMBGP4PIR` define a `ChannelNumbers.Name.Map` that translates spec channel numbers to bus protocol numbers (e.g. spec channel **09** → bus channel **10**).
   
In `_load_default_channels`, channels were stored under the spec number (`int(chan)` = **9**), but all message handlers (e.g. `_handle_sensor_temperature`) look up channels using `_translate_channel_name()`, which returns the
bus number (**10**). This mismatch caused a `KeyError: 10` on every temperature update.
                                                    
The bug was silently swallowed by `asyncio.ensure_future` (fire-and-forget) in older Python versions, but became a visible `ERROR` in Python 3.14 which logs unhandled task exceptions more strictly. Home Assistant
switched to Python 3.14 on 2026-01-28 (HA core #161426), making this error visible for the first time.
                 
### Fix

- Apply `_translate_channel_name()` when storing channels in `_load_default_channels`, so channels are keyed by their bus number
- Apply the same translation when restoring channel names from cache
- Add a guard in cache loading to skip channel numbers that don't exist (backwards compatibility with old caches written under the spec number)
                                                    
### Affected modules

Any module with a `ChannelNumbers.Name.Map` in its spec.