### PR TITLE
Use human-readable name for properties from module spec

### DIFF
--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -1227,7 +1227,7 @@ class Module:
                 continue
             self._properties[prop] = cls(
                 module=self,
-                name=prop,
+                name=prop_data.get("Name", prop),
                 writer=self._writer,
             )
 


### PR DESCRIPTION
### Problem
                     
In `_load_properties`, properties were initialised with `name=prop` — the dictionary key from the spec (e.g. `"light_value"`). The module spec also defines a human-readable `"Name"` field (e.g. `"Light value"`) that was being ignored.
                                            
As a result, entity names in Home Assistant showed the internal key (`light_value`) instead of the intended label (`Light value`).
       
### Fix
                                 
Use `prop_data.get("Name", prop)` when initialising the property name, so the human-readable label from the spec is used when showing the property in Home Assistant, with the key as fallback if no `"Name"` is defined.
                                 
### Example
                                                       
`VMBGP4PIR` (`2D.json`) defines:

```json
"Properties": { 
  "light_value": {
    "Name": "Light value", 
    "Type": "LightValue"
  }     
} 
```
                                              
Before: entity name = `light_value`
After: entity name = `Light value`