### PR TITLE
Fix/vmb8in counter sensor category

### DIFF
--- a/tests/channel_buttoncounter_test.py
+++ b/tests/channel_buttoncounter_test.py
@@ -16,15 +16,24 @@ class TestButtonCounter:
         button = ButtonCounter(
             mock_module, 1, "Counter", False, True, mock_writer, 0x01
         )
-        button._counter = True
+        button._counter = 100
         assert button.get_categories() == ["sensor"]
 
-    def test_get_categories_button_mode(self, mock_module, mock_writer):
-        """Test button counter categories in button mode."""
+    def test_get_categories_counter_mode_zero(self, mock_module, mock_writer):
+        """Test button counter categories when counter value is zero."""
         button = ButtonCounter(
             mock_module, 1, "Counter", False, True, mock_writer, 0x01
         )
-        button._counter = False
+        button._counter = 0
+        assert button.get_categories() == ["sensor"]
+
+    def test_get_categories_button_mode(self, mock_module, mock_writer):
+        """Test button counter categories in button mode (no data received yet)."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        # _counter=None means no counter status received; channel acts as button
+        assert button._counter is None
         assert button.get_categories() == ["binary_sensor", "button"]
 
     def test_is_counter_channel(self, mock_module, mock_writer):
@@ -32,11 +41,19 @@ class TestButtonCounter:
         button = ButtonCounter(
             mock_module, 1, "Counter", False, True, mock_writer, 0x01
         )
-        button._counter = True
+        button._counter = 100
         assert button.is_counter_channel()
 
-        button._counter = False
+        button._counter = None
         assert not button.is_counter_channel()
+
+    def test_is_counter_channel_zero_counter(self, mock_module, mock_writer):
+        """Test that a zero counter value still classifies as a counter channel."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._counter = 0
+        assert button.is_counter_channel()
 
     def test_get_sensor_type_counter(self, mock_module, mock_writer):
         """Test getting sensor type for counter."""
@@ -163,12 +180,55 @@ class TestButtonCounter:
         button = ButtonCounter(
             mock_module, 1, "Counter", False, True, mock_writer, 0x01
         )
-        button._counter = True
+        button._counter = 100
         button._Unit = VOLUME_LITERS_HOUR
         assert button.is_water()
 
         button._Unit = ENERGY_KILO_WATT_HOUR
         assert not button.is_water()
+
+    def test_energy_from_energy_field(self, mock_module, mock_writer):
+        """Test energy property returns kWh from _energy field (Wh)."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._energy = 100000  # 100000 Wh = 100.0 kWh
+        assert button.energy == 100.0
+
+    def test_energy_zero(self, mock_module, mock_writer):
+        """Test energy property when _energy is zero (valid reading, not unknown)."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._energy = 0
+        assert button.energy == 0.0
+
+    def test_energy_none_when_not_received(self, mock_module, mock_writer):
+        """Test energy property returns None when no energy data received yet."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        assert button.energy is None
+
+    def test_energy_fallback_for_kwh_counter(self, mock_module, mock_writer):
+        """Test energy property fallback to pulse-based calc for kWh counters."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._counter = 1000
+        button._pulses = 10
+        button._Unit = ENERGY_KILO_WATT_HOUR
+        assert button.energy == round(1000 / 10, 2)
+
+    def test_energy_fallback_not_used_for_water(self, mock_module, mock_writer):
+        """Test energy property does not use pulse-based calc for water counters."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._counter = 1000
+        button._pulses = 10
+        button._Unit = VOLUME_LITERS_HOUR
+        assert button.energy is None
 
 
 # Sensor Tests

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -407,13 +407,21 @@ class ButtonCounter(Button):
 
     def get_categories(self) -> list[str]:
         """Return the categories for this channel."""
-        if self._counter is not None or self._power is not None or self._energy is not None:
+        if (
+            self._counter is not None
+            or self._power is not None
+            or self._energy is not None
+        ):
             return ["sensor"]
         return ["binary_sensor", "button"]
 
     def is_counter_channel(self) -> bool:
         """Return if this channel is a counter channel."""
-        if self._counter is not None or self._power is not None or self._energy is not None:
+        if (
+            self._counter is not None
+            or self._power is not None
+            or self._energy is not None
+        ):
             return True
         return False
 
@@ -428,7 +436,11 @@ class ButtonCounter(Button):
         """Return the accumulated energy in kWh, or None if not yet received."""
         if self._energy is not None:
             return round(self._energy / 1000, 3)
-        if self._counter is not None and self._pulses and self._Unit == ENERGY_KILO_WATT_HOUR:
+        if (
+            self._counter is not None
+            and self._pulses
+            and self._Unit == ENERGY_KILO_WATT_HOUR
+        ):
             return round(self._counter / self._pulses, 2)
         return None
 

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -237,6 +237,11 @@ class Channel(BaseItem):
         """Return the sensor type."""
         return None
 
+    @property
+    def energy(self) -> float | None:
+        """Return the accumulated energy in kWh, or None if not applicable."""
+        return None
+
 
 class Blind(Channel):
     """A blind channel."""
@@ -418,9 +423,18 @@ class ButtonCounter(Button):
             return "counter"
         return None
 
+    @property
+    def energy(self) -> float | None:
+        """Return the accumulated energy in kWh, or None if not yet received."""
+        if self._energy is not None:
+            return round(self._energy / 1000, 3)
+        if self._counter is not None and self._pulses:
+            return round(self._counter / self._pulses, 2)
+        return None
+
     def get_state(self) -> int:
         """Return the current state of the counter."""
-        if self._energy:
+        if self._energy is not None:
             return self._energy
         # if we don't know the delay
         # or we don't know the unit

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -402,13 +402,13 @@ class ButtonCounter(Button):
 
     def get_categories(self) -> list[str]:
         """Return the categories for this channel."""
-        if self._counter:
+        if self._counter or self._power is not None or self._energy is not None:
             return ["sensor"]
         return ["binary_sensor", "button"]
 
     def is_counter_channel(self) -> bool:
         """Return if this channel is a counter channel."""
-        if self._counter:
+        if self._counter or self._power is not None or self._energy is not None:
             return True
         return False
 

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -407,13 +407,13 @@ class ButtonCounter(Button):
 
     def get_categories(self) -> list[str]:
         """Return the categories for this channel."""
-        if self._counter or self._power is not None or self._energy is not None:
+        if self._counter is not None or self._power is not None or self._energy is not None:
             return ["sensor"]
         return ["binary_sensor", "button"]
 
     def is_counter_channel(self) -> bool:
         """Return if this channel is a counter channel."""
-        if self._counter or self._power is not None or self._energy is not None:
+        if self._counter is not None or self._power is not None or self._energy is not None:
             return True
         return False
 
@@ -428,7 +428,7 @@ class ButtonCounter(Button):
         """Return the accumulated energy in kWh, or None if not yet received."""
         if self._energy is not None:
             return round(self._energy / 1000, 3)
-        if self._counter is not None and self._pulses:
+        if self._counter is not None and self._pulses and self._Unit == ENERGY_KILO_WATT_HOUR:
             return round(self._counter / self._pulses, 2)
         return None
 


### PR DESCRIPTION
### Add public energy property to Channel and ButtonCounter
Adds a public energy property to expose accumulated energy in kWh without requiring consumers to access the private _energy attribute directly.

**Changes:**

- Channel base class gets a default energy property returning None
- ButtonCounter overrides it to return _energy / 1000 if available, falling back to _counter / _pulses for channels that report accumulated energy via pulse count
- Fixes a bug in get_state() where a truthy check on _energy would incorrectly fall through to the power calculation when _energy is 0

**Motivation:**
This is needed by the Home Assistant velbus integration (home-assistant/core#168201) to avoid accessing _energy directly, which is brittle and flagged by linters.