### PR TITLE
velbus: add get_property_key_map helper function

### DIFF
--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -1,0 +1,20 @@
+"""Tests for helper functions."""
+
+from velbusaio.helpers import get_property_key_map
+
+
+def test_get_property_key_map_known_entries() -> None:
+    """Test that get_property_key_map returns known property entries."""
+    mapping = get_property_key_map()
+    assert isinstance(mapping, dict)
+    # Verify a few well-known property keys are present with correct class names
+    assert mapping.get("selected_program") == "SelectedProgram"
+    assert mapping.get("memo_text") == "MemoText"
+
+
+def test_get_property_key_map_no_duplicates() -> None:
+    """Test that get_property_key_map handles duplicate keys consistently."""
+    mapping = get_property_key_map()
+    # Keys should be unique (dict guarantees this), just verify it returns a dict
+    assert isinstance(mapping, dict)
+    assert len(mapping) > 0

--- a/velbusaio/helpers.py
+++ b/velbusaio/helpers.py
@@ -78,11 +78,11 @@ def get_property_key_map() -> dict[str, str]:
 
     Example: {"selected_program": "SelectedProgram", "memo_text": "MemoText"}
     """
-    spec_path = Path(
-        str(importlib.resources.files("velbusaio").joinpath("module_spec"))
-    )
+    spec_path = importlib.resources.files("velbusaio").joinpath("module_spec")
     mapping: dict[str, str] = {}
-    for spec_file in spec_path.glob("*.json"):
+    for spec_file in spec_path.iterdir():
+        if not spec_file.is_file() or not spec_file.name.endswith(".json"):
+            continue
         data = json.loads(spec_file.read_text())
         for key, prop_data in data.get("Properties", {}).items():
             type_ = prop_data.get("Type")

--- a/velbusaio/helpers.py
+++ b/velbusaio/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib.resources
+import json
 import os
 from pathlib import Path
 import re
@@ -69,6 +71,24 @@ def handle_match(match_dict: dict[str, dict[str, dict[str, str]]], data: int) ->
                     val = multi
                 result[int(res["Channel"])] = {res["Value"]: val}
     return result
+
+
+def get_property_key_map() -> dict[str, str]:
+    """Return a mapping of property spec key to class name for all module properties.
+
+    Example: {"selected_program": "SelectedProgram", "memo_text": "MemoText"}
+    """
+    spec_path = Path(
+        str(importlib.resources.files("velbusaio").joinpath("module_spec"))
+    )
+    mapping: dict[str, str] = {}
+    for spec_file in spec_path.glob("*.json"):
+        data = json.loads(spec_file.read_text())
+        for key, prop_data in data.get("Properties", {}).items():
+            type_ = prop_data.get("Type")
+            if type_ and key not in mapping:
+                mapping[key] = type_
+    return mapping
 
 
 def get_cache_dir() -> str:


### PR DESCRIPTION
Add a public function that returns a mapping of property spec keys to class names by reading the module_spec files. This allows integrations to use this mapping without reading velbusaio internals directly.

This is needed for [https://github.com/home-assistant/core/pull/167651](https://github.com/home-assistant/core/pull/167651): fix unique_id collision for Property sensor entities