### PR TITLE
helpers: change get_property_key_map to key by display name

### DIFF
--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -4,17 +4,18 @@ from velbusaio.helpers import get_property_key_map
 
 
 def test_get_property_key_map_known_entries() -> None:
-    """Test that get_property_key_map returns known property entries."""
+    """Test that get_property_key_map returns known display name entries."""
     mapping = get_property_key_map()
     assert isinstance(mapping, dict)
-    # Verify a few well-known property keys are present with correct class names
-    assert mapping.get("selected_program") == "SelectedProgram"
-    assert mapping.get("memo_text") == "MemoText"
+    assert mapping.get("Selected program") == "SelectedProgram"
+    assert mapping.get("Memo Text") == "MemoText"
 
 
-def test_get_property_key_map_no_duplicates() -> None:
-    """Test that get_property_key_map handles duplicate keys consistently."""
+def test_get_property_key_map_uses_display_names() -> None:
+    """Test that get_property_key_map keys are display names, not spec keys."""
     mapping = get_property_key_map()
-    # Keys should be unique (dict guarantees this), just verify it returns a dict
     assert isinstance(mapping, dict)
     assert len(mapping) > 0
+    # Spec keys must not appear; display names must
+    assert "selected_program" not in mapping
+    assert "Selected program" in mapping

--- a/velbusaio/helpers.py
+++ b/velbusaio/helpers.py
@@ -74,9 +74,13 @@ def handle_match(match_dict: dict[str, dict[str, dict[str, str]]], data: int) ->
 
 
 def get_property_key_map() -> dict[str, str]:
-    """Return a mapping of property spec key to class name for all module properties.
+    """Return a mapping of property display name to class name for all module properties.
 
-    Example: {"selected_program": "SelectedProgram", "memo_text": "MemoText"}
+    The display name is what Property.get_name() returns (the "Name" field from the
+    module spec, falling back to the spec key). This matches the original_name stored
+    in the HA entity registry.
+
+    Example: {"Selected program": "SelectedProgram", "Light value": "LightValue"}
     """
     spec_path = importlib.resources.files("velbusaio").joinpath("module_spec")
     mapping: dict[str, str] = {}
@@ -86,8 +90,9 @@ def get_property_key_map() -> dict[str, str]:
         data = json.loads(spec_file.read_text())
         for key, prop_data in data.get("Properties", {}).items():
             type_ = prop_data.get("Type")
-            if type_ and key not in mapping:
-                mapping[key] = type_
+            name = prop_data.get("Name", key)
+            if type_ and name not in mapping:
+                mapping[name] = type_
     return mapping
 
 


### PR DESCRIPTION
## Summary

`get_property_key_map()` was keyed on spec keys (e.g. `"selected_program"`), but
`Property.get_name()` returns the display name from the module spec JSON (e.g.
`"Selected program"` — capital letter, space instead of underscore). Home Assistant
stores this display name as `original_name` in the entity registry.

This mismatch made `property_key_map.get(entry.original_name)` always return `None`,
so the migration in home-assistant/core#167651 never ran in practice. The tests masked
this because they used the spec key as a mock value instead of the real display name.

## Changes

- `get_property_key_map()` now keys by display name (`prop_data.get("Name", key)`)
  instead of spec key, matching what `Property.get_name()` returns
- Updated tests to verify display names are used as keys and spec keys are absent

## Related

- home-assistant/core#167651