### PR TITLE
fix: wire up auto-reconnect and disconnect callbacks on connection loss

### DIFF
--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -155,6 +155,19 @@ class Velbus:
         """Return connection state."""
         return self._is_connected
 
+    async def _reconnect_loop(self) -> None:
+        """Keep retrying connect() until it succeeds or auto_reconnect is disabled."""
+        retry_delay = 10
+        while self._auto_reconnect and not self._closing:
+            try:
+                await self.connect()
+            except VelbusConnectionFailed:
+                self._log.debug("Reconnect failed, retrying in %ds", retry_delay)
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(retry_delay * 2, 300)
+            else:
+                return
+
     async def _on_connection_state(self, is_connected: bool) -> None:
         """Respond to Protocol connection state changes."""
         self._is_connected = is_connected
@@ -166,7 +179,7 @@ class Velbus:
                 await callback()
             if self._auto_reconnect and not self._closing:
                 self._log.debug("Reconnecting to transport")
-                task = asyncio.ensure_future(self.connect())
+                task = asyncio.ensure_future(self._reconnect_loop())
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
         for mod in self._modules.values():

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -162,7 +162,7 @@ class Velbus:
             try:
                 await self.connect()
             except VelbusConnectionFailed:
-                self._log.debug("Reconnect failed, retrying in %ds", retry_delay)
+                self._log.warning("Reconnect failed, retrying in %ds", retry_delay)
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, 300)
             else:

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -164,6 +164,11 @@ class Velbus:
         else:
             for callback in self._on_disconnect_callbacks:
                 await callback()
+            if self._auto_reconnect and not self._closing:
+                self._log.debug("Reconnecting to transport")
+                task = asyncio.ensure_future(self.connect())
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
         for mod in self._modules.values():
             for chan in mod.get_channels().values():
                 await chan.status_update()
@@ -175,14 +180,6 @@ class Velbus:
     async def _on_message_received(self, msg: RawMessage) -> None:
         """On message received function."""
         await self._handler.handle(msg)
-
-    def _on_connection_lost(self, exc: Exception) -> None:
-        """Respond to Protocol connection lost."""
-        if self._auto_reconnect and not self._closing:
-            self._log.debug("Reconnecting to transport")
-            task = asyncio.ensure_future(self.connect())
-            self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
 
     async def add_module(
         self,

--- a/velbusaio/protocol.py
+++ b/velbusaio/protocol.py
@@ -192,6 +192,8 @@ class VelbusProtocol(asyncio.BufferedProtocol):
             msg_info: RawMessage | None = await self._send_queue.get()
             if msg_info is None:
                 self._restart_writer = False
+                if self._write_transport_lock.locked():
+                    self._write_transport_lock.release()
                 return
             message_sent = False
             try:

--- a/velbusaio/protocol.py
+++ b/velbusaio/protocol.py
@@ -95,6 +95,7 @@ class VelbusProtocol(asyncio.BufferedProtocol):
     def connection_lost(self, exc: Exception | None) -> None:
         """Called when the Velbus connection is lost."""
         self.transport = None
+        self.pause_writing()
 
         if self._closing:
             return  # Connection loss was expected, nothing to do here...
@@ -103,8 +104,7 @@ class VelbusProtocol(asyncio.BufferedProtocol):
         else:
             self._log.error(f"Velbus connection lost: {exc!r}")
 
-        self.transport = None
-        self.pause_writing()
+        self._notify_connection_state_callbacks(False)
 
     # Everything read-related
 


### PR DESCRIPTION
## Problem

When the TCP connection to the Velbus interface is lost, asyncio calls `VelbusProtocol.connection_lost()`. This method set `transport = None` and stopped writing, but **never notified the controller**. As a result:

- Disconnect callbacks registered via `add_disconnect_callback()` were never called
- The auto-reconnect logic in the controller was never triggered
- The connection stayed broken silently until HA was restarted

The `_on_connection_lost()` method in the controller (which contained the reconnect logic) was effectively dead code — nothing called it.

## Fix

**`protocol.py`:**
- Call `_notify_connection_state_callbacks(False)` at the end of `connection_lost()` so the controller is informed of unexpected disconnects
- Move `pause_writing()` before the early `return` so it always runs, even on expected close

**`controller.py`:**
- Move the auto-reconnect logic into `_on_connection_state(False)`, which is now properly called
- Remove the dead `_on_connection_lost()` method