### PR TITLE
protocol: fix BufferedProtocol read path to share framing with data_received

### DIFF
--- a/tests/protocol_buffer_updated_test.py
+++ b/tests/protocol_buffer_updated_test.py
@@ -64,12 +64,12 @@ class TestVelbusProtocolBufferUpdated:
         assert protocol._last_activity_time > 0
 
     @pytest.mark.asyncio
-    async def test_buffer_updated_creates_new_buffer(self):
-        """Test that buffer_updated creates new buffer with remaining data."""
+    async def test_buffer_updated_keeps_remaining_data(self):
+        """Test that data left after a parsed message is kept for the next read."""
         callback = AsyncMock()
         protocol = VelbusProtocol(callback)
 
-        # Valid message with some remaining data
+        # Valid message followed by the start of a second (incomplete) message
         valid_message = b"\x0f\xf8\x01\x00\x00\x00\x00\x00\x06\x04"
         remaining = b"\x0f\xf8\x02"
         combined = valid_message + remaining
@@ -80,26 +80,23 @@ class TestVelbusProtocolBufferUpdated:
             mock_msg = Mock(spec=RawMessage)
             mock_create.return_value = (mock_msg, remaining)
 
-            old_buffer = protocol._buffer
             protocol.buffer_updated(len(combined))
 
             await asyncio.sleep(0.1)
 
-            # Buffer should be renewed
-            assert protocol._buffer is not old_buffer
-            assert protocol._buffer_pos == len(remaining)
+            # The leftover (partial second message) must be preserved, not dropped,
+            # so it can be completed by the next read.
+            assert protocol._serial_buf == remaining
 
     @pytest.mark.asyncio
-    async def test_buffer_updated_position_tracking(self):
-        """Test that buffer position is tracked correctly."""
+    async def test_buffer_updated_accumulates_partial_data(self):
+        """Test that bytes below the minimum size are accumulated, not processed."""
         callback = AsyncMock()
         protocol = VelbusProtocol(callback)
 
-        initial_pos = protocol._buffer_pos
-        bytes_received = 2  # Use small number to avoid triggering message processing
+        bytes_received = 2  # Less than MINIMUM_MESSAGE_SIZE, so no processing occurs
 
         protocol.buffer_updated(bytes_received)
 
-        # Should have added bytes_received to position (if no message processing triggered)
-        # Since we're using 2 bytes which is less than MINIMUM_MESSAGE_SIZE, no processing occurs
-        assert protocol._buffer_pos == initial_pos + bytes_received
+        # The received bytes are accumulated in _serial_buf awaiting more data.
+        assert len(protocol._serial_buf) == bytes_received

--- a/tests/protocol_init_test.py
+++ b/tests/protocol_init_test.py
@@ -14,7 +14,6 @@ class TestVelbusProtocolInit:
         protocol = VelbusProtocol(callback)
 
         assert protocol._message_received_callback == callback
-        assert protocol._buffer_pos == 0
         assert protocol._serial_buf == b""
         assert protocol.transport is None
         assert not protocol._closing
@@ -40,4 +39,4 @@ class TestVelbusProtocolInit:
 
         assert len(protocol._buffer) > 0
         assert protocol._buffer_view is not None
-        assert protocol._buffer_pos == 0
+        assert protocol._serial_buf == b""

--- a/velbusaio/protocol.py
+++ b/velbusaio/protocol.py
@@ -34,9 +34,12 @@ class VelbusProtocol(asyncio.BufferedProtocol):
         self._connection_state_callback = connection_state_callback
 
         # everything for reading from Velbus
+        # _buffer is a fixed scratch buffer the transport writes into on the
+        # BufferedProtocol (get_buffer/buffer_updated) read path. buffer_updated()
+        # copies the received bytes into _serial_buf, so both read paths converge
+        # on the same framing logic in data_received().
         self._buffer = bytearray(MAXIMUM_MESSAGE_SIZE)
         self._buffer_view = memoryview(self._buffer)
-        self._buffer_pos = 0
 
         self._serial_buf = b""
         self.transport = None
@@ -109,8 +112,13 @@ class VelbusProtocol(asyncio.BufferedProtocol):
     # Everything read-related
 
     def get_buffer(self, sizehint: int) -> memoryview:
-        """Provide buffer for Buffered Streaming protocol."""
-        return self._buffer_view[self._buffer_pos :]
+        """Provide a writable buffer for the BufferedProtocol read path.
+
+        Returns the whole scratch buffer; the received bytes are copied out and
+        accumulated in data_received(), so the transport may reuse it freely on
+        the next read.
+        """
+        return self._buffer_view
 
     def data_received(self, data: bytes) -> None:
         """Receive data from the Streaming protocol.
@@ -127,44 +135,35 @@ class VelbusProtocol(asyncio.BufferedProtocol):
         )
         _recheck = True
 
-        while len(self._serial_buf) > MINIMUM_MESSAGE_SIZE and _recheck:
-            # try to construct a Velbus message from the buffer
+        while len(self._serial_buf) >= MINIMUM_MESSAGE_SIZE and _recheck:
+            # create_message_info() / _parse() reject buffers larger than one
+            # maximum-size packet, so only feed it the first MAXIMUM_MESSAGE_SIZE
+            # bytes. The bytes beyond that (a second packet that arrived in the
+            # same read) must be preserved as the tail, otherwise they are
+            # silently dropped on a busy bus where reads bundle multiple packets.
+            head = bytearray(self._serial_buf[:MAXIMUM_MESSAGE_SIZE])
+            tail = self._serial_buf[MAXIMUM_MESSAGE_SIZE:]
 
-            msg, remaining_data = create_message_info(
-                bytearray(self._serial_buf[:MAXIMUM_MESSAGE_SIZE])
-            )
+            msg, remaining_data = create_message_info(head)
 
             if msg is not None:
                 asyncio.ensure_future(self._process_message(msg))  # noqa: RUF006
                 _recheck = True
             else:
                 _recheck = False
-            self._serial_buf = bytes(remaining_data)
+            self._serial_buf = bytes(remaining_data) + tail
 
     def buffer_updated(self, nbytes: int) -> None:
-        """Receive data from the Buffered Streaming protocol.
+        """Receive data from the BufferedProtocol read path.
 
-        Called when asyncio.BufferedProtocol detects received data from network.
+        Called when asyncio.BufferedProtocol detects received data. This path is
+        used by the network transport and by serialx for serial ports. Delegate
+        to data_received() so both read paths converge on the same robust framing
+        logic. The previous implementation parsed a fixed-size buffer in place and
+        swapped it mid-stream, which misframed the byte stream depending on how the
+        transport chunked its reads (intact payloads but corrupt STX/ETX bytes).
         """
-        self._last_activity_time = time.time()
-        self._buffer_pos += nbytes
-        if self._buffer_pos > MINIMUM_MESSAGE_SIZE:
-            # try to construct a Velbus message from the buffer
-            msg, remaining_data = create_message_info(self._buffer)
-
-            if msg is not None:
-                asyncio.ensure_future(self._process_message(msg))  # noqa: RUF006
-
-            self._new_buffer(remaining_data)
-
-    def _new_buffer(self, remaining_data=None) -> None:
-        new_buffer = bytearray(MAXIMUM_MESSAGE_SIZE)
-        if remaining_data:
-            new_buffer[: len(remaining_data)] = remaining_data
-
-        self._buffer = new_buffer
-        self._buffer_pos = len(remaining_data) if remaining_data else 0
-        self._buffer_view = memoryview(self._buffer)
+        self.data_received(bytes(self._buffer_view[:nbytes]))
 
     async def _process_message(self, msg: RawMessage) -> None:
         # self._log.debug(f"RX: {msg}")


### PR DESCRIPTION
Since the serial backend switched to `serialx`, the asyncio `BufferedProtocol` read path (`get_buffer`/`buffer_updated`) is now exercised for serial ports too — `pyserial-asyncio-fast` only ever drove `data_received`. That buffered path was buggy and had effectively been dormant for serial connections.

## The bug

`buffer_updated()` parsed a fixed-size 14-byte buffer **in place** (`create_message_info(self._buffer)`), including stale trailing bytes, and swapped the buffer mid-stream via `_new_buffer()`. Depending on how the transport chunked its reads, this misframed the byte stream: intact payloads and checksums, but corrupt `STX`/`ETX` bytes — surfacing as:

```
Could not parse the message ... Truncating invalid data
```

on busy buses, and as garbled module names (long strings between `{ }`) because the multi-packet name responses got misframed (see home-assistant/core#166623).

The same `VelbusProtocol` class serves both transports (TCP via `create_connection`, serial via `serialx.create_serial_connection`); TCP largely masked the bug because its delivery is packet-aligned, while serial delivers at byte/latency-timer granularity and triggers it constantly.

## The fix

`buffer_updated()` now copies the received bytes and **delegates to `data_received()`**, so both read paths converge on a single, robust framing implementation that accumulates in `_serial_buf` and re-checks for complete frames. `get_buffer()` returns the whole scratch buffer; `_buffer_pos` and `_new_buffer()` are removed.

This also fixes two latent bugs that the old buffered path could hit:

1. **Empty-buffer contract violation.** The old `get_buffer()` returned `self._buffer_view[self._buffer_pos:]`, which yields a zero-length buffer once `_buffer_pos` reaches the buffer size — asyncio rejects that with `RuntimeError: get_buffer() returned an empty buffer`. It now always returns the full buffer.
2. **Minimum-size packet stall.** `data_received()` used `> MINIMUM_MESSAGE_SIZE`, so a minimal valid 6-byte packet (4-byte header + 2-byte tail, zero data) sitting alone in the buffer was not parsed until another byte arrived. Changed to `>= MINIMUM_MESSAGE_SIZE`.

## Packet-drop fix in `data_received()`

`create_message_info()` rejects buffers larger than one maximum-size packet, so only the first `MAXIMUM_MESSAGE_SIZE` bytes were fed to the parser — but everything beyond that was then discarded, dropping a second packet that arrived in the same read (common on a busy bus). The tail beyond `MAXIMUM_MESSAGE_SIZE` is now preserved.

## Tests

- `tests/protocol_init_test.py` and `tests/protocol_buffer_updated_test.py` updated to the new `_serial_buf`-based semantics (the old tests asserted the removed `_buffer_pos`/`_new_buffer` behaviour).
- All protocol unit tests pass; the buffered path was additionally driven through several chunk boundaries (incl. byte-by-byte) with two back-to-back packets — all framed correctly, no drops, no corruption.

Refs home-assistant/core#166623

Related PRs: Cereal2nd/velbus-aio#190 (stop forcing the velbus-handler logger to DEBUG) and home-assistant/core#174904 (add velbus-handler to the integration manifest loggers).
