### PR TITLE
handler: do not force the velbus-handler logger to DEBUG

### DIFF
--- a/velbusaio/handler.py
+++ b/velbusaio/handler.py
@@ -41,7 +41,6 @@ class PacketHandler:
     ) -> None:
         """Initialize the PacketHandler class."""
         self._log = logging.getLogger("velbus-handler")
-        self._log.setLevel(logging.DEBUG)
         self._velbus = velbus
         self._one_address = one_address
         self._typeResponseReceived = asyncio.Event()


### PR DESCRIPTION
The `PacketHandler` constructor hardcoded:

```python
self._log.setLevel(logging.DEBUG)
```

which pinned the `velbus-handler` logger to `DEBUG` regardless of the application's logging configuration. Every other velbus-aio logger inherits the application level; only this one is forced.

In large installations this floods the log — Home Assistant reports `Module velbus-handler is logging too frequently. 200 messages since last count` (especially during the startup module scan) — and, more importantly, the user cannot turn the verbosity back down, because the hardcoded level overrides their config.

Removing the line lets the logger inherit the configured level like the others. Debug logging stays fully available on demand, e.g. in Home Assistant:

```yaml
logger:
  logs:
    velbus-handler: debug
```

(Separately, the Home Assistant `velbus` integration manifest should list `velbus-handler` in its `loggers` so the diagnostics UI recognises it — that is a home-assistant/core change.)

Refs home-assistant/core#166623

Related PRs: Cereal2nd/velbus-aio#189 (serialx framing fix) and home-assistant/core#174904 (add velbus-handler to the integration manifest loggers).
