### PR TITLE
Add is_long_pressed accessor for button channels

### DIFF
--- a/tests/channel_button_test.py
+++ b/tests/channel_button_test.py
@@ -33,6 +33,16 @@ class TestButton:
         assert not button.is_closed()
 
     @pytest.mark.asyncio
+    async def test_is_long_pressed(self, mock_module, mock_writer):
+        """Test checking if button is long pressed."""
+        button = Button(mock_module, 1, "Button", False, True, mock_writer, 0x01)
+        await button.update({"long": True})
+        assert button.is_long_pressed()
+
+        await button.update({"long": False})
+        assert not button.is_long_pressed()
+
+    @pytest.mark.asyncio
     async def test_is_on_led_on(self, mock_module, mock_writer):
         """Test checking if button LED is on."""
         button = Button(mock_module, 1, "Button", False, True, mock_writer, 0x01)

--- a/tests/channel_buttoncounter_test.py
+++ b/tests/channel_buttoncounter_test.py
@@ -1,5 +1,7 @@
 """Test cases for the ButtonCounter channel class"""
 
+import pytest
+
 from velbusaio.channels import ButtonCounter
 from velbusaio.const import (
     ENERGY_KILO_WATT_HOUR,
@@ -54,6 +56,18 @@ class TestButtonCounter:
         )
         button._counter = 0
         assert button.is_counter_channel()
+
+    @pytest.mark.asyncio
+    async def test_is_long_pressed(self, mock_module, mock_writer):
+        """Test inherited long-press state accessor."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        await button.update({"long": True})
+        assert button.is_long_pressed()
+
+        await button.update({"long": False})
+        assert not button.is_long_pressed()
 
     def test_get_sensor_type_counter(self, mock_module, mock_writer):
         """Test getting sensor type for counter."""

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -346,6 +346,10 @@ class Button(Channel):
         """Return if this button is on."""
         return self._closed
 
+    def is_long_pressed(self) -> bool:
+        """Return if this button is currently long pressed."""
+        return self._long
+
     def is_on(self) -> bool:
         """Return if this relay is on."""
         if self._led_state == "on":


### PR DESCRIPTION
## Summary
- add a public is_long_pressed() accessor on Button, inherited by ButtonCounter
- expose the existing tracked long-press state instead of relying on get_channel_info()[long]
- add focused tests for the new accessor

## Context
This is intended to support [home-assistant/core#175201](https://github.com/home-assistant/core/pull/175201).

Review feedback there pointed out that the Home Assistant integration should not read long-press state via get_channel_info(), since that method is effectively a diagnostics dump of channel internals. Adding a dedicated accessor in elbus-aio keeps runtime state access aligned with the library's existing public API, such as is_closed().

## Behavior
Velbus button modules first report PRESSED, then LONG_PRESSED if held, and RELEASED on release. elbus-aio already tracks that long-press state internally; this PR simply exposes it publicly through is_long_pressed(), which returns False again after release.