### PR TITLE
helpers: map both spec key and display name in get_property_key_map

### DIFF
--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -11,11 +11,14 @@ def test_get_property_key_map_known_entries() -> None:
     assert mapping.get("Memo Text") == "MemoText"
 
 
-def test_get_property_key_map_uses_display_names() -> None:
-    """Test that get_property_key_map keys are display names, not spec keys."""
+def test_get_property_key_map_includes_spec_keys_and_display_names() -> None:
+    """Test that both the spec key and the display name map to the class name.
+
+    original_name may be the spec key (velbus-aio < 2026.4.1) or the display name
+    (>= 2026.4.1, #181), so both forms must resolve to the same class name.
+    """
     mapping = get_property_key_map()
     assert isinstance(mapping, dict)
     assert len(mapping) > 0
-    # Spec keys must not appear; display names must
-    assert "selected_program" not in mapping
-    assert "Selected program" in mapping
+    assert mapping.get("selected_program") == "SelectedProgram"
+    assert mapping.get("Selected program") == "SelectedProgram"

--- a/velbusaio/helpers.py
+++ b/velbusaio/helpers.py
@@ -74,13 +74,14 @@ def handle_match(match_dict: dict[str, dict[str, dict[str, str]]], data: int) ->
 
 
 def get_property_key_map() -> dict[str, str]:
-    """Return a mapping of property display name to class name for all module properties.
+    """Return a mapping of every property name ever used to its class name.
 
-    The display name is what Property.get_name() returns (the "Name" field from the
-    module spec, falling back to the spec key). This matches the original_name stored
-    in the HA entity registry.
+    Property.get_name() returned the spec key (e.g. "light_value") before #181 and
+    the "Name" field from the module spec (e.g. "Light value") from #181 onwards.
+    Both forms may be stored as original_name in the HA entity registry, so both are
+    mapped to the class name to keep unique_id migration working for either version.
 
-    Example: {"Selected program": "SelectedProgram", "Light value": "LightValue"}
+    Example: {"light_value": "LightValue", "Light value": "LightValue"}
     """
     spec_path = importlib.resources.files("velbusaio").joinpath("module_spec")
     mapping: dict[str, str] = {}
@@ -90,9 +91,10 @@ def get_property_key_map() -> dict[str, str]:
         data = json.loads(spec_file.read_text())
         for key, prop_data in data.get("Properties", {}).items():
             type_ = prop_data.get("Type")
-            name = prop_data.get("Name", key)
-            if type_ and name not in mapping:
-                mapping[name] = type_
+            if not type_:
+                continue
+            for name in (key, prop_data.get("Name", key)):
+                mapping.setdefault(name, type_)
     return mapping
 
 


### PR DESCRIPTION
`Property.get_name()` returned the **spec key** (e.g. `light_value`) before #181 and the **"Name"** field (e.g. `Light value`) from #181 onwards. Both forms are therefore stored as `original_name` in the Home Assistant entity registry depending on which velbus-aio version created the entity (#181 shipped in 2026.4.1).

#185 keyed the map by display name only, which misses entities created before #181; the released 2026.4.1 keys by spec key only, which misses entities created after it. This maps **both** forms to the class name so the HA `unique_id` migration works for either upgrade path.

Needed by home-assistant/core#176343.
