### PR TITLE
module: always return the serial number as a str

### DIFF
--- a/tests/module_serial_test.py
+++ b/tests/module_serial_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from velbusaio.module import Module
+
+
+@pytest.mark.parametrize(
+    ("serial", "expected"),
+    [
+        # the bus reports the serial as an int (struct.unpack of the module type message)
+        (12345, "12345"),
+        # a serial of 0 is a valid value, it must not be dropped
+        (0, "0"),
+        # a vlp file reports the serial as a str, it should be passed through as is
+        ("0A1B2C", "0A1B2C"),
+        # an unknown serial stays None
+        (None, None),
+    ],
+)
+def test_module_serial_is_normalized(serial, expected):
+    m = Module(1, 0x0E, serial=serial)
+
+    assert m.get_serial() == expected
+    assert m.serial == expected
+    if expected is not None:
+        assert isinstance(m.get_serial(), str)
+
+
+def test_module_factory_serial_is_normalized():
+    m = Module.factory(1, 0x0E, 12345)
+
+    assert m.get_serial() == "12345"

--- a/velbusaio/baseItem.py
+++ b/velbusaio/baseItem.py
@@ -67,7 +67,7 @@ class BaseItem(ABC):
         return self._module.get_type_name()
 
     @final
-    def get_module_serial(self) -> str:
+    def get_module_serial(self) -> str | None:
         """Return module serial number."""
         return self._module.get_serial()
 

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -198,7 +198,7 @@ class Velbus:
         self,
         addr: int,
         typ: int,
-        serial: int | None = None,
+        serial: int | str | None = None,
         memorymap: int | None = None,
         build_year: int | None = None,
         build_week: int | None = None,

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -119,7 +119,7 @@ class Module:
         cls,
         module_address: int,
         module_type: int,
-        serial: int | None = None,
+        serial: int | str | None = None,
         memorymap: int | None = None,
         build_year: int | None = None,
         build_week: int | None = None,
@@ -154,7 +154,7 @@ class Module:
         self,
         module_address: int,
         module_type: int,
-        serial: int | None = None,
+        serial: int | str | None = None,
         memorymap: int | None = None,
         build_year: int | None = None,
         build_week: int | None = None,
@@ -171,7 +171,8 @@ class Module:
             int, str
         ] = {}  # temporary buffer while assembling name from memory blocks
         self._sub_address = {}
-        self.serial = serial
+        # the bus reports the serial as an int, a vlp file as a str => normalize
+        self.serial = str(serial) if serial is not None else None
         self.memory_map_version = memorymap
         self.build_year = build_year
         self.build_week = build_week
@@ -1288,7 +1289,7 @@ class VmbDali(Module):
         self,
         module_address: int,
         module_type: int,
-        serial: int | None = None,
+        serial: int | str | None = None,
         memorymap: int | None = None,
         build_year: int | None = None,
         build_week: int | None = None,


### PR DESCRIPTION
## Problem

`Module` receives the serial number from two sources with two different types:

| source | type |
|---|---|
| bus discovery — `handler.py` ← `struct.unpack(">L", …)` in `messages/module_type.py` | `int` |
| vlp project file — `controller.py` ← JSON | `str` |

`Module.__init__` stored it as received, even though `get_serial()` was already annotated
`-> str | None` and `BaseItem.get_module_serial()` even `-> str`. So the annotations did not
match reality.

Home Assistant passes `get_module_serial()` straight into the device registry, which now logs:

```
Detected that custom integration 'velbus' passes a non-string value of type int as
serial_number to the device registry ... This will stop working in Home Assistant 2026.12.0
```

## Change

- Normalize in `Module.__init__`: `self.serial = str(serial) if serial is not None else None`,
  so the public attribute and the getter agree.
- Widen the `serial` parameter annotation to `int | str | None` on `Module.factory`,
  `Module.__init__`, `VmbDali.__init__` and `Velbus.add_module`, documenting the two sources.
- Correct `BaseItem.get_module_serial()` to `-> str | None`, which is what it has always returned.

## Compatibility

No unique_id change on the Home Assistant side: it builds `f"{serial}-{channel}"`, and `12345`
and `"12345"` format identically.

No cache migration: `to_cache()` does not store the serial, it is always taken fresh from the
bus or the vlp file.

## Tests

New `tests/module_serial_test.py` covers an int serial, a serial of `0` (must not be dropped),
a vlp-style str and `None`. Full suite: 220 passed.