### PR TITLE
module: fix bus error counter properties never being updated

### DIFF
--- a/tests/module_bus_error_counter_test.py
+++ b/tests/module_bus_error_counter_test.py
@@ -1,0 +1,47 @@
+"""This test checks that an incoming bus error counter message is stored into the
+bus error counter properties of the module.
+"""
+
+import pathlib
+
+import pytest
+
+from velbusaio.controller import Velbus
+from velbusaio.helpers import get_cache_dir
+from velbusaio.messages.bus_error_counter_status import BusErrorCounterStatusMessage
+from velbusaio.module import Module
+from velbusaio.properties import BusErrorOff, BusErrorRx, BusErrorTx
+
+VMBGPOD = 0x28
+
+# distinct values, so a mix-up between the three counters is caught as well
+TRANSMIT_ERRORS = 11
+RECEIVE_ERRORS = 22
+BUS_OFF_COUNT = 33
+
+
+@pytest.mark.asyncio
+async def test_bus_error_counters_are_updated():
+    cache_dir = get_cache_dir()
+    pathlib.Path(cache_dir).mkdir(parents=True, exist_ok=True)
+
+    m = Module(1, VMBGPOD, cache_dir=cache_dir)
+    velbus = Velbus("")  # Dummy connection
+    await m.initialize(velbus.send, velbus)
+
+    # the bus error counters are declared in module_spec/global.json, so every module
+    # gets them; load them the way _load_properties() does
+    m._properties["bus_error_tx"] = BusErrorTx(m, "Bus Error Transmit", velbus.send)
+    m._properties["bus_error_rx"] = BusErrorRx(m, "Bus Error Receive", velbus.send)
+    m._properties["bus_error_off"] = BusErrorOff(m, "Bus Error Off", velbus.send)
+
+    msg = BusErrorCounterStatusMessage(1)
+    msg.transmit_error_counter = TRANSMIT_ERRORS
+    msg.receive_error_counter = RECEIVE_ERRORS
+    msg.bus_off_counter = BUS_OFF_COUNT
+
+    await m._handle_bus_error_counter(msg)
+
+    assert m._properties["bus_error_tx"].get_state() == TRANSMIT_ERRORS
+    assert m._properties["bus_error_rx"].get_state() == RECEIVE_ERRORS
+    assert m._properties["bus_error_off"].get_state() == BUS_OFF_COUNT

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -507,12 +507,12 @@ class Module:
     ) -> None:
         """Handle bus error counter status messages."""
         await self._update_property(
-            "BusErrorTx", {"_cur": message.transmit_error_counter}
+            "bus_error_tx", {"cur": message.transmit_error_counter}
         )
         await self._update_property(
-            "BusErrorRx", {"_cur": message.receive_error_counter}
+            "bus_error_rx", {"cur": message.receive_error_counter}
         )
-        await self._update_property("BusOffCounter", {"_cur": message.bus_off_counter})
+        await self._update_property("bus_error_off", {"cur": message.bus_off_counter})
 
     async def _handle_relay_status(
         self, message: RelayStatusMessage | RelayStatusMessage2


### PR DESCRIPTION
## Problem

`Module._handle_bus_error_counter()` never reached the properties it was supposed to update. The three bus error counters (`bus_error_tx`, `bus_error_rx`, `bus_error_off`) always reported `0`, no matter what the bus reported.

These properties are declared in `velbusaio/module_spec/global.json`, so every module is affected.

There are **two independent bugs**, and they mask each other — fixing only one still leaves the counters at `0`:

### 1. Wrong property keys

`velbusaio/module.py:509-515` looked the properties up by their `Type` name:

```python
await self._update_property("BusErrorTx", {"_cur": message.transmit_error_counter})
await self._update_property("BusErrorRx", {"_cur": message.receive_error_counter})
await self._update_property("BusOffCounter", {"_cur": message.bus_off_counter})
```

But `_properties` is keyed on the **module_spec key**: `module.py:1233` does `self._properties[prop] = cls(...)` where `prop` is the JSON key, and `global.json` declares `bus_error_tx` / `bus_error_rx` / `bus_error_off` (with `"Type"` being `BusErrorTx` etc.). `"BusOffCounter"` matches neither a key nor a Type.

All three lookups therefore raised `KeyError`, which `_update_property` (`module.py:905-908`) catches and logs at **info** level — so nothing showed up in a normal log.

### 2. Wrong update key

`BaseItem.update()` (`velbusaio/baseItem.py:149-151`) does `setattr(self, f"_{key}", new_val)`. Passing `"_cur"` therefore writes to `__cur`, while `BusErrorTx.get_state()` (`velbusaio/properties.py:165,169`) returns `float(self._cur)`.

`_handle_module_status_pir()` (`module.py:718`) shows the correct pattern: `_update_property("light_value", {"cur": ...})`.

## Fix

Use the module_spec keys and the `cur` update key.

## Testing

New test `tests/module_bus_error_counter_test.py` drives a `BusErrorCounterStatusMessage` through `_handle_bus_error_counter()` and asserts each counter reports its value. It uses three distinct non-zero values, so a mix-up between tx/rx/off is caught as well — and asserting on non-zero matters, because a test expecting `0` would pass against the broken code.

I verified the test isolates both bugs:

| State | Result |
|---|---|
| `master` (both bugs) | fails, `_cur = 0` |
| only the keys fixed | fails, `_cur = 0, __cur = 11` — value arrives, wrong attribute |
| only `cur` fixed | fails, `_cur = 0`, no `__cur` — update never reaches the property |
| both fixed | passes |

Full suite: 221 passed. All pre-commit lint hooks pass (the `pytest` hook fails in its isolated env on missing `aiofile`/`serialx`, identically on unmodified test files — pre-existing).
