### PR TITLE
module_spec: add the selected_program property to the VMBPIRM (0x2A)

### DIFF
--- a/velbusaio/module_spec/2A.json
+++ b/velbusaio/module_spec/2A.json
@@ -56,6 +56,10 @@
     "light_value": {
       "Name": "Light value",
       "Type": "LightValue"
+    },
+    "selected_program": {
+      "Name": "Selected program",
+      "Type": "SelectedProgram"
     }
   },
   "Type": "VMBPIRM"


### PR DESCRIPTION
## Problem

The VMBPIRM maps command `0xED` to `ModuleStatusPirMessage`, and `Module._handle_module_status_pir()` unconditionally writes the parsed program to the `selected_program` property. `2A.json` never declared that property, so every PIR status message logs:

```
ERROR [velbus-module] property selected_program does not exist for module @ address
<Sensor gang type:42 address:84 loaded:True ... properties: {'bus_error_off': ...,
'light_value': <class 'velbusaio.properties.LightValue'>[... _cur = 38]}>
```

The mismatch is not new, but 2026.7.3 raised the failure path of `_update_property()` from `self._log.info` to `self._log.error`, which is why it now shows up in the Home Assistant log. On a busy bus this repeats for every status message.

## Why the spec is the right place to fix it

The VMBPIRM is the only module using `ModuleStatusPirMessage` that does not declare the property:

| Type | Module | `ED` handler | `selected_program` |
|---|---|---|---|
| 0x2A | **VMBPIRM** | `ModuleStatusPirMessage` | ❌ missing |
| 0x2B | VMBPIRC | `ModuleStatusPirMessage` | ✅ |
| 0x2C | VMBPIRO | `ModuleStatusPirMessage` | ✅ |
| 0x38 | VMBELPIR | `ModuleStatusPirMessage` | ✅ |

`2A.json` also maps `B3` to `SelectProgramMessage`, so the module does support program selection and the property belongs there. Guarding the write in the handler instead would leave the VMBPIRM inconsistent with its three siblings.

## Verification

Building a `Module(module_type=0x2A)`, calling `initialize()` + `_load_default_channels()` + `_load_properties()` and feeding it a `ModuleStatusPirMessage`:

| | properties | error log |
|---|---|---|
| before | `bus_error_*`, `light_value` | `property selected_program does not exist ...` |
| after | + `selected_program` | none, value parses as `'summer'` |

Full test suite: 468 passed.

I also audited all 94 module specs (command byte -> message class from the spec's `CommandToClass`, -> handler from `_build_message_handlers`, -> the properties that handler writes). 0x2A is the only spec that is missing a property one of its handlers writes, so this is the complete fix for that class of mismatch.

Consumers get one extra entity for the VMBPIRM. No cache migration is needed: `_load_properties()` builds purely from the spec and the cache is only ever written, never read back for properties.

## Note for a follow-up

The audit did turn up the mirror-image mismatch in 15 specs -- properties that are declared but that no incoming message ever writes, so they stay empty forever. Two clusters: PIR/EL modules whose `ED` points at the generic `ModuleStatusMessage` (VMBPIRO-10, VMBEL2PIR, VMBPIR-20, VMBEL1PIR-20, VMBPIRO-20, VMBEL2PIR-20, and VMBEL4PIR-20 for `light_value` only), and non-PIR modules declaring `selected_program` with no status message that reports it (VMB4LEDPWM-20, VMB1RYNO, VMB2DC-20, VMB1RYNOS, VMB1BLS, VMBMETEO, VMB4AN, VMBKP, VMB8DC-20). I have deliberately left those out of this PR: deciding whether those `ED` mappings are wrong needs the protocol documentation or the actual hardware, and a wrong mapping would misparse messages, which is worse than an empty entity. Happy to open a separate issue with the full table if useful.