### PR TITLE
channels: derive the counter power from the pulse interval

### DIFF
--- a/tests/channel_buttoncounter_test.py
+++ b/tests/channel_buttoncounter_test.py
@@ -173,13 +173,53 @@ class TestButtonCounter:
         assert button.get_counter_state() == 250.5
 
     def test_get_counter_state_calculated(self, mock_module, mock_writer):
-        """Test getting calculated counter state."""
+        """Test the counter state is derived from the pulse interval."""
         button = ButtonCounter(
             mock_module, 1, "Counter", False, True, mock_writer, 0x01
         )
+        button._Unit = ENERGY_KILO_WATT_HOUR
         button._counter = 1000
         button._pulses = 10
-        assert button.get_counter_state() == 100.0
+        button._delay = 1000
+        expected = (1000 * 1000 * 3600) / (1000 * 10)
+        assert button.get_counter_state() == round(expected, 2)
+
+    def test_get_counter_state_differs_from_energy(self, mock_module, mock_writer):
+        """A module without CounterValueMessage must not report power == energy.
+
+        Modules such as the VMB7IN only send a CounterStatusMessage, so _power
+        and _energy stay None. Both values used to fall back to counter/pulses,
+        which made the power and energy sensors in Home Assistant identical.
+        """
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._Unit = ENERGY_KILO_WATT_HOUR
+        button._counter = 1000
+        button._pulses = 10
+        button._delay = 1000
+        assert button._power is None
+        assert button._energy is None
+        assert button.get_counter_state() != button.energy
+
+    def test_get_counter_state_without_delay(self, mock_module, mock_writer):
+        """Test the counter state is 0 while the pulse interval is unknown."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._Unit = ENERGY_KILO_WATT_HOUR
+        button._counter = 1000
+        button._pulses = 10
+        assert button.get_counter_state() == 0
+
+    def test_get_state_without_pulses(self, mock_module, mock_writer):
+        """Test the rate is 0 instead of raising when the pulses are unknown."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._Unit = ENERGY_KILO_WATT_HOUR
+        button._delay = 1000
+        assert button.get_state() == 0
 
     def test_get_counter_unit(self, mock_module, mock_writer):
         """Test getting counter unit."""

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -450,24 +450,34 @@ class ButtonCounter(Button):
             return round(self._counter / self._pulses, 2)
         return None
 
+    def _rate_from_pulse_interval(self) -> float:
+        """Return the instantaneous rate derived from the interval between pulses.
+
+        Only VMB8IN-20 maps a CounterValueMessage, so on every other counter
+        module _power stays None and the rate has to be derived from _delay.
+        """
+        # if we don't know the delay or the pulses
+        # or we don't know the unit
+        # or the delay is the max value
+        #   we always return 0
+        if (
+            not self._delay
+            or not self._pulses
+            or not self._Unit
+            or self._delay == 0xFFFF
+        ):
+            return round(0, 2)
+        if self._Unit in {VOLUME_LITERS_HOUR, VOLUME_CUBIC_METER_HOUR}:
+            return round((1000 * 3600) / (self._delay * self._pulses), 2)
+        if self._Unit == ENERGY_KILO_WATT_HOUR:
+            return round((1000 * 1000 * 3600) / (self._delay * self._pulses), 2)
+        return round(0, 2)
+
     def get_state(self) -> int:
         """Return the current state of the counter."""
         if self._energy is not None:
             return self._energy
-        # if we don't know the delay
-        # or we don't know the unit
-        # or the delay is the max value
-        #   we always return 0
-        val = 0
-        if not self._delay or not self._Unit or self._delay == 0xFFFF:
-            return round(0, 2)
-        if self._Unit in {VOLUME_LITERS_HOUR, VOLUME_CUBIC_METER_HOUR}:
-            val = (1000 * 3600) / (self._delay * self._pulses)
-        elif self._Unit == ENERGY_KILO_WATT_HOUR:
-            val = (1000 * 1000 * 3600) / (self._delay * self._pulses)
-        else:
-            val = 0
-        return round(val, 2)
+        return self._rate_from_pulse_interval()
 
     def get_unit(self) -> str | None:
         """Return the unit of the counter."""
@@ -484,12 +494,15 @@ class ButtonCounter(Button):
         self._Unit = unit
 
     def get_counter_state(self) -> int:
-        """Return the current state of the counter."""
+        """Return the instantaneous power (or flow) of the counter.
+
+        Falls back to the pulse interval when the module does not report
+        _power; returning the accumulated counter here would duplicate the
+        energy property.
+        """
         if self._power:
             return self._power
-        if not self._counter or not self._pulses:
-            return 0
-        return round((self._counter / self._pulses), 2)
+        return self._rate_from_pulse_interval()
 
     def get_counter_unit(self) -> str:
         """Return the unit of the counter."""


### PR DESCRIPTION
## Problem

`ButtonCounter.get_counter_state()` returns the accumulated counter divided by the pulses whenever `_power` is unset:

```python
def get_counter_state(self) -> int:
    if self._power:
        return self._power
    if not self._counter or not self._pulses:
        return 0
    return round((self._counter / self._pulses), 2)   # <-- accumulated value
```

The `energy` property falls back to **exactly the same expression**:

```python
if self._counter is not None and self._pulses and self._Unit == ENERGY_KILO_WATT_HOUR:
    return round(self._counter / self._pulses, 2)
```

So on any module that does not report `_power`, both return an identical value.

`_power` and `_energy` are populated only by `Module._handle_counter_value()`, which runs only for a `CounterValueMessage`. Across all 94 module specs, exactly one maps that message:

| Spec | Module | `CounterValueMessage` |
|---|---|---|
| 0x4E | VMB8IN-20 | yes |
| 0x22 | VMB7IN | no — only `BE -> CounterStatusMessage` |
| all others | | no |

So on a VMB7IN both stay `None` for ever and the fallback always applies.

## Why it shows up now

home-assistant/core#168201 wired the two sensors of a counter channel to different accessors — the power sensor to `get_counter_state()` and the energy sensor to the `energy` property. That split is right, but on a VMB7IN it makes both sensors display the same number, where the power sensor is expected to show the instantaneous value. Reported by a user on a real VMB7IN.

## Fix

`get_counter_state()` now falls back to the rate derived from the interval between pulses — the calculation `get_state()` already performed. The shared formula moves into `_rate_from_pulse_interval()`.

With `_Unit = kWh`, `_counter = 1000`, `_pulses = 10`, `_delay = 1000`:

| | before | after |
|---|---|---|
| `get_counter_state()` | 100.0 | **360000.0** |
| `energy` | 100.0 | 100.0 |

The helper also guards against `_pulses` being unset. `get_state()` checked `_delay` and `_Unit` but not `_pulses`, so it raised `ZeroDivisionError` when the delay and unit were known before the pulses arrived.

## Tests

471 pass. `test_get_counter_state_calculated` asserted the duplicated behaviour and is updated. Three tests added: the power/energy values must differ on a module without `CounterValueMessage`, the rate is 0 while the pulse interval is unknown, and `get_state()` returns 0 instead of raising when the pulses are unknown.

Refs home-assistant/core#168201