### PR TITLE
module_spec: put every spec on the newest memory map, and refuse writes to modules that predate it

### DIFF
--- a/tests/action_table_guard_test.py
+++ b/tests/action_table_guard_test.py
@@ -1,0 +1,148 @@
+"""Test cases for the reserved-memory guard around action tables."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from velbusaio.actions import build_action_tables, reserved_ranges
+from velbusaio.memory import MemoryBackend
+
+# The VMB4RYLD layout that shipped before the fix: a table sized for firmware
+# that predates the module name, combined with the name that only the later
+# firmware has. Slots 37 and 38 and the NO/NC byte land inside the name.
+BROKEN_RELAY_SPEC = {
+    "actions": "relay_classic",
+    "slot_count": 39,
+    "slot_size": 6,
+    "channels": {
+        "01": {"bank": "0000", "noc_address": "00EA"},
+        "02": {"bank": "0100", "noc_address": "01EA"},
+    },
+}
+RELAY_MEMORY = {
+    "ModuleName": "00E3-00EF;01E3-01EF",
+    "Channels": {"01": "00F0-00FF", "02": "01F0-01FF"},
+    "ActionTable": BROKEN_RELAY_SPEC,
+}
+
+
+@pytest.fixture(name="backend")
+def backend_fixture() -> MemoryBackend:
+    """Return a memory backend with a stubbed writer."""
+    return MemoryBackend(0x20, AsyncMock())
+
+
+class TestReservedRanges:
+    """Test cases for reserved_ranges()."""
+
+    def test_collects_module_and_channel_names(self) -> None:
+        """Both the module name and every channel name are protected."""
+        assert reserved_ranges(RELAY_MEMORY) == [
+            (0x00E3, 0x00EF),
+            (0x01E3, 0x01EF),
+            (0x00F0, 0x00FF),
+            (0x01F0, 0x01FF),
+        ]
+
+    @pytest.mark.parametrize(
+        "spec", [None, {}, {"ModuleName": ""}, {"ModuleName": "garbage"}]
+    )
+    def test_missing_or_unparsable_yields_nothing(self, spec) -> None:
+        """A spec without usable ranges guards nothing rather than raising."""
+        assert reserved_ranges(spec) == []
+
+
+class TestActionTableGuard:
+    """Test cases for the guard applied in build_action_tables()."""
+
+    def test_slots_are_clamped_to_reserved_memory(self, backend) -> None:
+        """Slots that would reach into the name are dropped.
+
+        The name starts at 0x00E3, so with 6-byte slots only 37 fit (0..36,
+        ending at 0x00DD). Slots 37 and 38 would have run to 0x00E9.
+        """
+        tables = build_action_tables(
+            backend, BROKEN_RELAY_SPEC, reserved=reserved_ranges(RELAY_MEMORY)
+        )
+
+        assert tables[1].slot_count == 37
+        assert tables[1].bank + tables[1].slot_count * tables[1].slot_size - 1 < 0x00E3
+
+    def test_guard_applies_per_bank(self, backend) -> None:
+        """Each channel is measured against the reserved range in its own bank."""
+        tables = build_action_tables(
+            backend, BROKEN_RELAY_SPEC, reserved=reserved_ranges(RELAY_MEMORY)
+        )
+
+        assert tables[2].slot_count == 37
+        assert tables[2].bank + tables[2].slot_count * tables[2].slot_size - 1 < 0x01E3
+
+    def test_colliding_noc_address_is_dropped(self, backend) -> None:
+        """A NO/NC byte inside the name is never read or written."""
+        tables = build_action_tables(
+            backend, BROKEN_RELAY_SPEC, reserved=reserved_ranges(RELAY_MEMORY)
+        )
+
+        assert tables[1].noc_address is None
+        assert tables[2].noc_address is None
+
+    def test_guard_warns_about_what_it_dropped(self, backend, caplog) -> None:
+        """The operator gets told, so a wrong spec is visible rather than silent."""
+        caplog.set_level(logging.WARNING)
+        build_action_tables(
+            backend, BROKEN_RELAY_SPEC, reserved=reserved_ranges(RELAY_MEMORY)
+        )
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "only 37 fit before reserved memory" in messages
+        assert "NO/NC address 0x00EA" in messages
+
+    def test_correct_spec_is_left_alone(self, backend, caplog) -> None:
+        """A spec that already agrees with the firmware keeps every slot."""
+        caplog.set_level(logging.WARNING)
+        spec = {
+            **BROKEN_RELAY_SPEC,
+            "slot_count": 36,
+            "channels": {
+                "01": {"bank": "0000", "noc_address": "00D8"},
+                "02": {"bank": "0100", "noc_address": "01D8"},
+            },
+        }
+
+        tables = build_action_tables(
+            backend, spec, reserved=reserved_ranges(RELAY_MEMORY)
+        )
+
+        assert tables[1].slot_count == 36
+        assert tables[1].noc_address == 0x00D8
+        assert caplog.records == []
+
+    def test_without_reserved_nothing_is_clamped(self, backend) -> None:
+        """The guard is opt-in, so existing callers keep their behaviour."""
+        tables = build_action_tables(backend, BROKEN_RELAY_SPEC)
+
+        assert tables[1].slot_count == 39
+        assert tables[1].noc_address == 0x00EA
+
+    def test_shared_table_is_clamped_once(self, backend, caplog) -> None:
+        """A table shared by every channel is measured against its single bank."""
+        caplog.set_level(logging.WARNING)
+        spec = {
+            "actions": "input_v2",
+            "layout": "shared",
+            "subject_encoding": "param2",
+            "bank": "0100",
+            "slot_count": 60,
+            "slot_size": 5,
+            "channels": {"01": {}, "02": {}},
+        }
+
+        tables = build_action_tables(backend, spec, reserved=[(0x0200, 0x023F)])
+
+        # 0x0100 up to 0x01FF is 256 bytes, so 51 five-byte slots fit.
+        assert tables[1].slot_count == 51
+        assert tables[2].slot_count == 51
+        assert "only 51 fit before reserved memory" in caplog.text

--- a/tests/module_memory_map_build_test.py
+++ b/tests/module_memory_map_build_test.py
@@ -1,0 +1,188 @@
+"""Test the memory map build check on Module."""
+
+import glob
+import json
+import logging
+import os
+import pathlib
+import re
+
+import pytest
+
+from velbusaio.exceptions import VelbusMemoryWriteBlocked
+from velbusaio.module import Module
+
+SPEC_DIR = pathlib.Path(__file__).parent.parent / "velbusaio" / "module_spec"
+
+# 0x10 VMB4RYLD declares MemoryMapBuild 1409, 0x12 VMB4DC declares 1915 and
+# 0x13 VMBLCDWB declares none.
+VMB4RYLD = 0x10
+VMB4DC = 0x12
+VMBLCDWB = 0x13
+
+
+class MockWriter:
+    async def __call__(self, data):
+        pass
+
+
+class MockController:
+    """Mock controller for testing."""
+
+    def connected(self):
+        return True
+
+    def _add_on_connext_callback(self, callback):
+        pass
+
+    def _remove_on_connect_callback(self, callback):
+        pass
+
+    def _add_on_disconnect_callback(self, callback):
+        pass
+
+    def _remove_on_disconnect_callback(self, callback):
+        pass
+
+
+async def _build(module_type, year, week):
+    module = Module(1, module_type, build_year=year, build_week=week)
+    module._use_cache = False
+    await module.initialize(MockWriter(), MockController())
+    return module
+
+
+def _mismatch_warnings(caplog):
+    return [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "memory map from build" in r.message
+    ]
+
+
+@pytest.mark.asyncio
+async def test_older_build_warns(caplog):
+    """A module predating the spec's memory map is reported."""
+    with caplog.at_level(logging.WARNING, logger="velbus-module"):
+        await _build(VMB4DC, year=18, week=2)
+
+    warnings = _mismatch_warnings(caplog)
+    assert len(warnings) == 1
+    assert "reports build 1802" in warnings[0].message
+    assert "from build 1915 onwards" in warnings[0].message
+
+
+@pytest.mark.asyncio
+async def test_exact_build_is_quiet(caplog):
+    """The first build the map applies to is a match, not a mismatch."""
+    with caplog.at_level(logging.WARNING, logger="velbus-module"):
+        await _build(VMB4RYLD, year=14, week=9)
+
+    assert _mismatch_warnings(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_one_week_older_warns(caplog):
+    """Week 8 of year 14 is 1408, which is below 1409.
+
+    This only holds if the week is zero padded; an unpadded "148" would
+    compare as greater than "1409" and the mismatch would go unnoticed.
+    """
+    with caplog.at_level(logging.WARNING, logger="velbus-module"):
+        await _build(VMB4RYLD, year=14, week=8)
+
+    warnings = _mismatch_warnings(caplog)
+    assert len(warnings) == 1
+    assert "reports build 1408" in warnings[0].message
+
+
+@pytest.mark.asyncio
+async def test_newer_build_is_quiet(caplog):
+    """Firmware newer than the documented map is the normal case."""
+    with caplog.at_level(logging.WARNING, logger="velbus-module"):
+        await _build(VMB4DC, year=25, week=1)
+
+    assert _mismatch_warnings(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_spec_without_build_is_quiet(caplog):
+    """Most specs declare no build; those must never warn."""
+    with caplog.at_level(logging.WARNING, logger="velbus-module"):
+        await _build(VMBLCDWB, year=10, week=1)
+
+    assert _mismatch_warnings(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_module_without_build_is_quiet(caplog):
+    """A module restored from a cache may not carry build information."""
+    with caplog.at_level(logging.WARNING, logger="velbus-module"):
+        await _build(VMB4DC, year=None, week=None)
+
+    assert _mismatch_warnings(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_outdated_module_is_flagged_for_home_assistant():
+    """The mismatch is state, not only a log line, so HA can show it."""
+    module = await _build(VMB4DC, year=18, week=2)
+
+    assert module.is_memory_map_outdated() is True
+    assert module.get_build() == "1802"
+    assert module.get_memory_map_build() == "1915"
+
+
+@pytest.mark.asyncio
+async def test_current_module_is_not_flagged():
+    """A module on current firmware carries no flag."""
+    module = await _build(VMB4DC, year=25, week=1)
+
+    assert module.is_memory_map_outdated() is False
+    assert module.get_memory_map_build() == "1915"
+
+
+@pytest.mark.asyncio
+async def test_writes_are_refused_on_an_outdated_module():
+    """Writing would corrupt the module, so it must fail loudly."""
+    module = await _build(VMB4DC, year=18, week=2)
+    memory = module.get_memory()
+
+    assert memory.writes_blocked is True
+    with pytest.raises(VelbusMemoryWriteBlocked):
+        await memory.write_byte(0x00E0, 0x41)
+    with pytest.raises(VelbusMemoryWriteBlocked):
+        await memory.write_bytes(0x00E0, b"ABCD")
+
+
+@pytest.mark.asyncio
+async def test_writes_are_allowed_on_a_current_module():
+    """The guard must not block modules that are fine."""
+    module = await _build(VMB4DC, year=25, week=1)
+
+    assert module.get_memory().writes_blocked is False
+
+
+@pytest.mark.asyncio
+async def test_writes_are_allowed_when_no_build_is_declared():
+    """Specs without a declared build can never block writes."""
+    module = await _build(VMBLCDWB, year=10, week=1)
+
+    assert module.is_memory_map_outdated() is False
+    assert module.get_memory().writes_blocked is False
+
+
+def test_declared_builds_are_four_digit_strings():
+    """MemoryMapBuild is a zero padded "YYWW" string, never an int."""
+    for path in sorted(glob.glob(os.path.join(SPEC_DIR, "*.json"))):
+        spec = json.loads(pathlib.Path(path).read_text())
+        if "MemoryMapBuild" not in spec:
+            continue
+        value = spec["MemoryMapBuild"]
+        assert isinstance(value, str), (
+            f"{os.path.basename(path)}: MemoryMapBuild is "
+            f"{type(value).__name__}, expected str"
+        )
+        assert re.fullmatch(r"\d{4}", value), (
+            f"{os.path.basename(path)}: MemoryMapBuild {value!r} is not YYWW"
+        )

--- a/tests/module_spec_memory_test.py
+++ b/tests/module_spec_memory_test.py
@@ -1,0 +1,106 @@
+"""Test cases for the memory maps declared in module_spec/*.json"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+SPEC_DIR = Path(__file__).parent.parent / "velbusaio" / "module_spec"
+SPECS = sorted(SPEC_DIR.glob("*.json"))
+
+
+def parse_ranges(value: str | None) -> list[tuple[int, int]]:
+    """Parse 'AAAA-BBBB;CCCC-DDDD' into inclusive integer ranges."""
+    out: list[tuple[int, int]] = []
+    for part in (value or "").split(";"):
+        part = part.strip()
+        if "-" not in part:
+            continue
+        lo, hi = part.split("-", 1)
+        out.append((int(lo, 16), int(hi, 16)))
+    return out
+
+
+def declared_regions(spec: dict) -> list[tuple[int, int, str]]:
+    """Return every (start, end, label) region a spec lays claim to in EEPROM."""
+    memory = spec.get("Memory") or {}
+    regions: list[tuple[int, int, str]] = []
+
+    for low, high in parse_ranges(memory.get("ModuleName")):
+        regions.append((low, high, "ModuleName"))
+
+    for channel, value in (memory.get("Channels") or {}).items():
+        if isinstance(value, str):
+            for low, high in parse_ranges(value):
+                regions.append((low, high, f"ChannelName[{channel}]"))
+
+    table = memory.get("ActionTable")
+    if table:
+        span = table["slot_count"] * table["slot_size"]
+        # Two shapes exist: one table shared by every channel (bank on the table
+        # itself), or one table per channel (bank on each channel entry).
+        shared_bank = table.get("bank")
+        if shared_bank is not None:
+            base = int(str(shared_bank), 16)
+            regions.append((base, base + span - 1, "ActionTable"))
+        for channel, config in (table.get("channels") or {}).items():
+            if not isinstance(config, dict):
+                continue
+            bank = config.get("bank")
+            if bank is not None:
+                base = int(str(bank), 16)
+                regions.append((base, base + span - 1, f"ActionTable[{channel}]"))
+            noc = config.get("noc_address")
+            if noc is not None:
+                addr = int(str(noc), 16)
+                regions.append((addr, addr, f"NOC[{channel}]"))
+
+    return regions
+
+
+@pytest.mark.parametrize("path", SPECS, ids=lambda p: p.name)
+def test_memory_regions_do_not_overlap(path: Path) -> None:
+    """Two claims on one EEPROM address means one of them is wrong.
+
+    The action table, the NO/NC contact byte, the channel names and the module
+    name each occupy their own area of module memory. An overlap is not
+    cosmetic: reading returns bytes belonging to something else, and writing
+    corrupts it. VMB4RYLD, VMB4RYNO, VMB1RYNO, VMBDMI and VMBDMI-R all carried
+    an action table sized for a firmware build that predates the module name,
+    so the last slots -- and for the relays the NO/NC byte -- landed inside the
+    name.
+    """
+    spec = json.loads(path.read_text())
+    regions = declared_regions(spec)
+
+    overlaps = [
+        f"{label_a} 0x{low_a:04X}-0x{high_a:04X} overlaps "
+        f"{label_b} 0x{low_b:04X}-0x{high_b:04X}"
+        for index, (low_a, high_a, label_a) in enumerate(regions)
+        for low_b, high_b, label_b in regions[index + 1 :]
+        if low_a <= high_b and low_b <= high_a
+    ]
+
+    assert not overlaps, f"{path.name} ({spec.get('Type')}): " + "; ".join(overlaps)
+
+
+@pytest.mark.parametrize("path", SPECS, ids=lambda p: p.name)
+def test_action_table_is_fully_specified(path: Path) -> None:
+    """An action table without slot_count/slot_size/bank cannot be addressed."""
+    spec = json.loads(path.read_text())
+    table = (spec.get("Memory") or {}).get("ActionTable")
+    if table is None:
+        pytest.skip("no action table")
+
+    assert table["slot_count"] > 0
+    assert table["slot_size"] > 0
+    assert table["channels"], "an action table needs at least one channel"
+
+    shared_bank = table.get("bank")
+    for channel, config in table["channels"].items():
+        assert isinstance(config, dict), f"channel {channel} is not a mapping"
+        bank = config.get("bank", shared_bank)
+        assert bank is not None, f"channel {channel} has no bank and none is shared"
+        int(str(bank), 16)

--- a/velbusaio/actions.py
+++ b/velbusaio/actions.py
@@ -26,7 +26,7 @@ channel number (glass panels / -20 inputs). Unused slots are 0xFF.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 import importlib.resources
 import json
@@ -731,12 +731,64 @@ class ActionTable:
         )
 
 
+def reserved_ranges(memory_spec: dict[str, Any] | None) -> list[tuple[int, int]]:
+    """Return the EEPROM ranges an action table must never touch.
+
+    The module name and the channel names live in the same address space as the
+    action table. A spec that sizes its table for the wrong firmware build runs
+    straight into them: reading returns name characters dressed up as actions,
+    and writing corrupts the name.
+    """
+    ranges: list[tuple[int, int]] = []
+    if not memory_spec:
+        return ranges
+
+    sources = [memory_spec.get("ModuleName")]
+    sources.extend(
+        value
+        for value in (memory_spec.get("Channels") or {}).values()
+        if isinstance(value, str)
+    )
+    for source in sources:
+        for raw_part in (source or "").split(";"):
+            part = raw_part.strip()
+            if "-" not in part:
+                continue
+            low, _, high = part.partition("-")
+            try:
+                ranges.append((int(low, 16), int(high, 16)))
+            except ValueError:
+                continue
+    return ranges
+
+
+def _slots_before_reserved(
+    bank: int, slot_count: int, slot_size: int, reserved: Sequence[tuple[int, int]]
+) -> int:
+    """Return how many slots fit between bank and the nearest reserved range."""
+    limit = min(
+        (low for low, _high in reserved if low > bank),
+        default=None,
+    )
+    if limit is None:
+        return slot_count
+    return max(0, min(slot_count, (limit - bank) // slot_size))
+
+
 def build_action_tables(
     memory: MemoryBackend,
     spec: dict[str, Any],
     logger: logging.Logger | None = None,
+    *,
+    reserved: Sequence[tuple[int, int]] | None = None,
 ) -> dict[int, ActionTable]:
-    """Build per-channel ActionTable instances from a module_spec ActionTable block."""
+    """Build per-channel ActionTable instances from a module_spec ActionTable block.
+
+    `reserved` holds ranges the table must stay out of, as returned by
+    reserved_ranges(). Slots that would fall inside one are dropped and a
+    NO/NC address that lands in one is ignored, so a spec that disagrees with
+    the module's firmware costs a few slots instead of the module name.
+    """
     if not spec:
         return {}
     log = logger or _LOGGER
@@ -754,17 +806,30 @@ def build_action_tables(
         release_bit = bool(release_bit)
     channels = spec.get("channels", {})
     tables: dict[int, ActionTable] = {}
+    guard = list(reserved or ())
 
     shared_store: _SharedSlotStore | None = None
     shared_bank = 0
+    shared_slot_count = slot_count
     if layout == "shared":
         if subject_encoding is None:
             raise VelbusConfigError("Shared action tables require subject_encoding")
         shared_bank = int(str(spec["bank"]), 16)
+        shared_slot_count = _slots_before_reserved(
+            shared_bank, slot_count, slot_size, guard
+        )
+        if shared_slot_count < slot_count:
+            log.warning(
+                "Action table at 0x%04X declares %d slots but only %d fit before "
+                "reserved memory; ignoring the rest",
+                shared_bank,
+                slot_count,
+                shared_slot_count,
+            )
         shared_store = _SharedSlotStore(
             memory,
             bank=shared_bank,
-            slot_count=slot_count,
+            slot_count=shared_slot_count,
             slot_size=slot_size,
             catalog_id=catalog_id,
             subject_encoding=subject_encoding,
@@ -775,13 +840,40 @@ def build_action_tables(
     for chan_key, chan_spec in channels.items():
         channel = int(chan_key)
         bank = shared_bank if layout == "shared" else int(str(chan_spec["bank"]), 16)
+        if layout == "shared":
+            channel_slot_count = shared_slot_count
+        else:
+            channel_slot_count = _slots_before_reserved(
+                bank, slot_count, slot_size, guard
+            )
+            if channel_slot_count < slot_count:
+                log.warning(
+                    "Action table for channel %d at 0x%04X declares %d slots but "
+                    "only %d fit before reserved memory; ignoring the rest",
+                    channel,
+                    bank,
+                    slot_count,
+                    channel_slot_count,
+                )
+
         noc = chan_spec.get("noc_address")
         noc_address = int(str(noc), 16) if noc is not None else None
+        if noc_address is not None and any(
+            low <= noc_address <= high for low, high in guard
+        ):
+            log.warning(
+                "NO/NC address 0x%04X for channel %d falls inside reserved memory; "
+                "not reading or writing it",
+                noc_address,
+                channel,
+            )
+            noc_address = None
+
         tables[channel] = ActionTable(
             memory,
             channel=channel,
             bank=bank,
-            slot_count=slot_count,
+            slot_count=channel_slot_count,
             slot_size=slot_size,
             catalog_id=catalog_id,
             noc_address=noc_address,

--- a/velbusaio/exceptions.py
+++ b/velbusaio/exceptions.py
@@ -40,6 +40,21 @@ class VelbusMemoryTimeout(VelbusException):
         )
 
 
+class VelbusMemoryWriteBlocked(VelbusException):
+    """Exception when writing to a module's memory would corrupt it.
+
+    A module running firmware older than the memory map its spec describes
+    lays its eeprom out differently, so every address in the spec is
+    suspect. Reading returns unrelated bytes; writing destroys whatever
+    really lives at that address.
+    """
+
+    def __init__(self, reason: str) -> None:
+        """Initialize the exception."""
+        super().__init__(f"Refusing to write to memory: {reason}")
+        self.reason = reason
+
+
 class VelbusConfigError(VelbusException):
     """Exception for configuration / action-table errors."""
 

--- a/velbusaio/memory.py
+++ b/velbusaio/memory.py
@@ -13,7 +13,7 @@ import struct
 from typing import Final
 
 from velbusaio.const import PRIORITY_LOW, SLEEP_TIME
-from velbusaio.exceptions import VelbusMemoryTimeout
+from velbusaio.exceptions import VelbusMemoryTimeout, VelbusMemoryWriteBlocked
 from velbusaio.message import Message
 from velbusaio.messages.memory_data import MemoryDataMessage
 from velbusaio.messages.memory_data_block import MemoryDataBlockMessage
@@ -61,6 +61,20 @@ class MemoryBackend:
         self._cache: dict[int, int] = {}
         self._waiters: dict[int, asyncio.Future[bytes]] = {}
         self._lock = asyncio.Lock()
+        self._write_blocked_reason: str | None = None
+
+    def block_writes(self, reason: str) -> None:
+        """Refuse every further write, because they would corrupt memory."""
+        self._write_blocked_reason = reason
+
+    @property
+    def writes_blocked(self) -> bool:
+        """Whether writing to this module's memory is refused."""
+        return self._write_blocked_reason is not None
+
+    def _assert_writable(self) -> None:
+        if self._write_blocked_reason is not None:
+            raise VelbusMemoryWriteBlocked(self._write_blocked_reason)
 
     @property
     def cache(self) -> dict[int, int]:
@@ -158,12 +172,14 @@ class MemoryBackend:
 
     async def write_byte(self, address: int, value: int) -> None:
         """Write one memory byte and wait for the 0xFE acknowledgement."""
+        self._assert_writable()
         async with self._lock:
             await self._write_byte_unlocked(address, value & 0xFF)
             await asyncio.sleep(_WRITE_BYTE_GAP)
 
     async def write_bytes(self, start: int, data: bytes) -> None:
         """Write a contiguous memory range using 4-byte blocks when possible."""
+        self._assert_writable()
         if not data:
             return
         async with self._lock:

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -19,7 +19,12 @@ if TYPE_CHECKING:
     from velbusaio.controller import Velbus as Controller
 
 from velbusaio import channels as channels_module, properties as properties_module
-from velbusaio.actions import ActionSlot, ActionTable, build_action_tables
+from velbusaio.actions import (
+    ActionSlot,
+    ActionTable,
+    build_action_tables,
+    reserved_ranges,
+)
 from velbusaio.channels import (
     Button,
     ButtonCounter,
@@ -269,10 +274,12 @@ class Module:
         # set some params from the velbus controller
         self._writer = writer
         self._memory = MemoryBackend(self._address, writer, self._log)
+        memory_spec = self._data.get("Memory", {})
         self._action_tables = build_action_tables(
             self._memory,
-            self._data.get("Memory", {}).get("ActionTable", {}),
+            memory_spec.get("ActionTable", {}),
             self._log,
+            reserved=reserved_ranges(memory_spec),
         )
         temp_chan: int | None = None
         if "TemperatureChannel" in self._data:

--- a/velbusaio/module.py
+++ b/velbusaio/module.py
@@ -188,6 +188,9 @@ class Module:
         self.memory_map_version = memorymap
         self.build_year = build_year
         self.build_week = build_week
+        # Set when the module's firmware predates the memory map its spec
+        # describes. Home Assistant surfaces this, and writes are refused.
+        self._memory_map_outdated = False
         self._cache_dir = cache_dir
         self._is_loading = False
         self._got_status = asyncio.Event()
@@ -267,6 +270,8 @@ class Module:
                 elif isinstance(value, dict) and isinstance(self._data[key], dict):
                     self._data[key] = {**value, **self._data[key]}
 
+        self._check_memory_map_build()
+
         commandRegistry.register_module_commands(
             self._type, self._data.get("CommandToClass", {})
         )
@@ -274,6 +279,11 @@ class Module:
         # set some params from the velbus controller
         self._writer = writer
         self._memory = MemoryBackend(self._address, writer, self._log)
+        if self._memory_map_outdated:
+            self._memory.block_writes(
+                f"module build {self.get_build()} predates the memory map from "
+                f"build {self.get_memory_map_build()} that its spec describes"
+            )
         memory_spec = self._data.get("Memory", {})
         self._action_tables = build_action_tables(
             self._memory,
@@ -293,6 +303,56 @@ class Module:
         )
         for chan in self._channels.values():
             chan.set_writer(writer)
+
+    def get_build(self) -> str | None:
+        """Return the firmware build as "YYWW", or None when unknown."""
+        if self.build_year is None or self.build_week is None:
+            return None
+        return f"{self.build_year:02d}{self.build_week:02d}"
+
+    def get_memory_map_build(self) -> str | None:
+        """Return the build from which this spec's memory map applies."""
+        return self._data.get("MemoryMapBuild")
+
+    def is_memory_map_outdated(self) -> bool:
+        """Whether the module predates the memory map its spec describes.
+
+        When true the spec's addresses do not match this module's eeprom,
+        so its memory must not be written. Home Assistant surfaces this so
+        the mismatch is visible instead of silently corrupting data.
+        """
+        return self._memory_map_outdated
+
+    def _check_memory_map_build(self) -> None:
+        """Determine whether the module predates its spec's memory map.
+
+        Modules report their firmware build as year and week. The protocol
+        documents state the build from which each memory map applies, and
+        MemoryMapBuild records the one this spec was written against. A
+        module older than that runs an earlier layout, so every address in
+        the spec is suspect: reading a name or an action table returns
+        whatever else lives there, and writing destroys it.
+        """
+        self._memory_map_outdated = False
+        expected = self.get_memory_map_build()
+        reported = self.get_build()
+        if expected is None or reported is None:
+            return
+        # "YYWW", the same shape vlp_reader compares build numbers in.
+        if len(reported) != len(expected):
+            self._log.debug(f"Cannot compare build {reported} to {expected}")
+            return
+        if reported >= expected:
+            return
+
+        self._memory_map_outdated = True
+        self._log.warning(
+            f"Module {self._address} ({h2(self._type)}) reports build "
+            f"{reported}, but the module spec describes the memory map from "
+            f"build {expected} onwards. Memory addresses may be wrong; names "
+            f"and action tables read from this module can be incorrect, so "
+            f"writing to its memory is refused."
+        )
 
     def cleanupSubChannels(self) -> None:
         """Cleanup subchannels that are not defined."""

--- a/velbusaio/module_spec/02.json
+++ b/velbusaio/module_spec/02.json
@@ -30,5 +30,6 @@
       "01": "0070-007F"
     }
   },
+  "MemoryMapBuild": "0814",
   "Type": "VMB1RY"
 }

--- a/velbusaio/module_spec/03.json
+++ b/velbusaio/module_spec/03.json
@@ -35,5 +35,6 @@
       "01": "0070-007F"
     }
   },
+  "MemoryMapBuild": "0815",
   "Type": "VMB1BL"
 }

--- a/velbusaio/module_spec/07.json
+++ b/velbusaio/module_spec/07.json
@@ -40,5 +40,6 @@
       "01": "00F0-00FF"
     }
   },
+  "MemoryMapBuild": "0819",
   "Type": "VMB1DM"
 }

--- a/velbusaio/module_spec/08.json
+++ b/velbusaio/module_spec/08.json
@@ -81,5 +81,6 @@
       "04": "03F0-03FF"
     }
   },
+  "MemoryMapBuild": "1025",
   "Type": "VMB4RY"
 }

--- a/velbusaio/module_spec/09.json
+++ b/velbusaio/module_spec/09.json
@@ -36,5 +36,6 @@
       "02": "01F0-01FF"
     }
   },
+  "MemoryMapBuild": "0815",
   "Type": "VMB2BL"
 }

--- a/velbusaio/module_spec/0C.json
+++ b/velbusaio/module_spec/0C.json
@@ -40,6 +40,7 @@
       "01": "00F0-00FF"
     }
   },
+  "MemoryMapBuild": "1233",
   "TemperatureChannel": "01",
   "Thermostat": "yes",
   "Type": "VMB1TS"

--- a/velbusaio/module_spec/0F.json
+++ b/velbusaio/module_spec/0F.json
@@ -40,5 +40,6 @@
       "01": "00F0-00FF"
     }
   },
+  "MemoryMapBuild": "0947",
   "Type": "VMB1LED"
 }

--- a/velbusaio/module_spec/10.json
+++ b/velbusaio/module_spec/10.json
@@ -92,5 +92,6 @@
     },
     "ModuleName": "00E3-00EF;01E3-01EF;02E3-02EF;03E3-03EF;04E3-04EE"
   },
+  "MemoryMapBuild": "1409",
   "Type": "VMB4RYLD"
 }

--- a/velbusaio/module_spec/10.json
+++ b/velbusaio/module_spec/10.json
@@ -61,26 +61,26 @@
       "channels": {
         "01": {
           "bank": "0000",
-          "noc_address": "00EA"
+          "noc_address": "00D8"
         },
         "02": {
           "bank": "0100",
-          "noc_address": "01EA"
+          "noc_address": "01D8"
         },
         "03": {
           "bank": "0200",
-          "noc_address": "02EA"
+          "noc_address": "02D8"
         },
         "04": {
           "bank": "0300",
-          "noc_address": "03EA"
+          "noc_address": "03D8"
         },
         "05": {
           "bank": "0400",
-          "noc_address": "04EA"
+          "noc_address": "04D8"
         }
       },
-      "slot_count": 39,
+      "slot_count": 36,
       "slot_size": 6
     },
     "Channels": {

--- a/velbusaio/module_spec/11.json
+++ b/velbusaio/module_spec/11.json
@@ -92,5 +92,6 @@
     },
     "ModuleName": "00E3-00EF;01E3-01EF;02E3-02EF;03E3-03EF;04E3-04EE"
   },
+  "MemoryMapBuild": "1409",
   "Type": "VMB4RYNO"
 }

--- a/velbusaio/module_spec/11.json
+++ b/velbusaio/module_spec/11.json
@@ -61,26 +61,26 @@
       "channels": {
         "01": {
           "bank": "0000",
-          "noc_address": "00EA"
+          "noc_address": "00D8"
         },
         "02": {
           "bank": "0100",
-          "noc_address": "01EA"
+          "noc_address": "01D8"
         },
         "03": {
           "bank": "0200",
-          "noc_address": "02EA"
+          "noc_address": "02D8"
         },
         "04": {
           "bank": "0300",
-          "noc_address": "03EA"
+          "noc_address": "03D8"
         },
         "05": {
           "bank": "0400",
-          "noc_address": "04EA"
+          "noc_address": "04D8"
         }
       },
-      "slot_count": 39,
+      "slot_count": 36,
       "slot_size": 6
     },
     "Channels": {

--- a/velbusaio/module_spec/12.json
+++ b/velbusaio/module_spec/12.json
@@ -74,6 +74,7 @@
     },
     "ModuleName": "00E0-00EF;01E0-01EF;02E0-02EF;03E0-03EF"
   },
+  "MemoryMapBuild": "1915",
   "Type": "VMB4DC",
   "sliderScale": 100
 }

--- a/velbusaio/module_spec/14.json
+++ b/velbusaio/module_spec/14.json
@@ -39,5 +39,6 @@
       "01": "00F0-00FF"
     }
   },
+  "MemoryMapBuild": "0819",
   "Type": "VMBDME"
 }

--- a/velbusaio/module_spec/15.json
+++ b/velbusaio/module_spec/15.json
@@ -36,7 +36,7 @@
           "bank": "0000"
         }
       },
-      "slot_count": 37,
+      "slot_count": 24,
       "slot_size": 6
     },
     "Channels": {

--- a/velbusaio/module_spec/15.json
+++ b/velbusaio/module_spec/15.json
@@ -44,5 +44,6 @@
     },
     "ModuleName": "00B0-00EF"
   },
+  "MemoryMapBuild": "1410",
   "Type": "VMBDMI"
 }

--- a/velbusaio/module_spec/16.json
+++ b/velbusaio/module_spec/16.json
@@ -110,6 +110,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1409",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/17.json
+++ b/velbusaio/module_spec/17.json
@@ -110,6 +110,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1409",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/18.json
+++ b/velbusaio/module_spec/18.json
@@ -110,6 +110,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1409",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/1A.json
+++ b/velbusaio/module_spec/1A.json
@@ -76,5 +76,6 @@
     },
     "ModuleName": "02C0-02FF"
   },
+  "MemoryMapBuild": "1409",
   "Type": "VMB4RF"
 }

--- a/velbusaio/module_spec/1B.json
+++ b/velbusaio/module_spec/1B.json
@@ -89,6 +89,7 @@
     },
     "ModuleName": "00E3-00EF;01E3-01EF;02E3-02EF;03E3-03EF;04E3-04EE"
   },
+  "MemoryMapBuild": "1409",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/1B.json
+++ b/velbusaio/module_spec/1B.json
@@ -58,26 +58,26 @@
       "channels": {
         "01": {
           "bank": "0000",
-          "noc_address": "00EA"
+          "noc_address": "00D8"
         },
         "02": {
           "bank": "0100",
-          "noc_address": "01EA"
+          "noc_address": "01D8"
         },
         "03": {
           "bank": "0200",
-          "noc_address": "02EA"
+          "noc_address": "02D8"
         },
         "04": {
           "bank": "0300",
-          "noc_address": "03EA"
+          "noc_address": "03D8"
         },
         "05": {
           "bank": "0400",
-          "noc_address": "04EA"
+          "noc_address": "04D8"
         }
       },
-      "slot_count": 39,
+      "slot_count": 36,
       "slot_size": 6
     },
     "Channels": {

--- a/velbusaio/module_spec/1D.json
+++ b/velbusaio/module_spec/1D.json
@@ -61,5 +61,6 @@
     },
     "ModuleName": "004C-008B"
   },
+  "MemoryMapBuild": "1409",
   "Type": "VMB2BLE"
 }

--- a/velbusaio/module_spec/1E.json
+++ b/velbusaio/module_spec/1E.json
@@ -173,6 +173,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1415",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/1F.json
+++ b/velbusaio/module_spec/1F.json
@@ -173,6 +173,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1415",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/20.json
+++ b/velbusaio/module_spec/20.json
@@ -173,6 +173,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1415",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/21.json
+++ b/velbusaio/module_spec/21.json
@@ -359,6 +359,7 @@
     },
     "ModuleName": "09BE-09FD"
   },
+  "MemoryMapBuild": "1415",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/22.json
+++ b/velbusaio/module_spec/22.json
@@ -190,6 +190,7 @@
     },
     "ModuleName": "03AC-03EB"
   },
+  "MemoryMapBuild": "1424",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/25.json
+++ b/velbusaio/module_spec/25.json
@@ -359,6 +359,7 @@
     },
     "ModuleName": "09BE-09FD"
   },
+  "MemoryMapBuild": "1415",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/28.json
+++ b/velbusaio/module_spec/28.json
@@ -367,6 +367,7 @@
     },
     "ModuleName": "09BE-09FD"
   },
+  "MemoryMapBuild": "1640",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/2E.json
+++ b/velbusaio/module_spec/2E.json
@@ -50,6 +50,7 @@
     },
     "ModuleName": "004C-008B"
   },
+  "MemoryMapBuild": "1935",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/2F.json
+++ b/velbusaio/module_spec/2F.json
@@ -36,7 +36,7 @@
           "bank": "0000"
         }
       },
-      "slot_count": 37,
+      "slot_count": 24,
       "slot_size": 6
     },
     "Channels": {

--- a/velbusaio/module_spec/2F.json
+++ b/velbusaio/module_spec/2F.json
@@ -44,5 +44,6 @@
     },
     "ModuleName": "00B0-00EF"
   },
+  "MemoryMapBuild": "1915",
   "Type": "VMBDMI-R"
 }

--- a/velbusaio/module_spec/34.json
+++ b/velbusaio/module_spec/34.json
@@ -180,6 +180,7 @@
     },
     "ModuleName": "06C0-06FF"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/35.json
+++ b/velbusaio/module_spec/35.json
@@ -180,6 +180,7 @@
     },
     "ModuleName": "06C0-06FF"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/36.json
+++ b/velbusaio/module_spec/36.json
@@ -180,6 +180,7 @@
     },
     "ModuleName": "06C0-06FF"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/37.json
+++ b/velbusaio/module_spec/37.json
@@ -332,6 +332,7 @@
     },
     "ModuleName": "0FA8-0FE7"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/38.json
+++ b/velbusaio/module_spec/38.json
@@ -151,6 +151,7 @@
     },
     "ModuleName": "0678-06B7"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "light_value": {
       "Name": "Light value",

--- a/velbusaio/module_spec/39.json
+++ b/velbusaio/module_spec/39.json
@@ -14,5 +14,6 @@
   "Memory": {
     "ModuleName": "0000-003F"
   },
+  "MemoryMapBuild": "1948",
   "Type": "VMBSIG"
 }

--- a/velbusaio/module_spec/3A.json
+++ b/velbusaio/module_spec/3A.json
@@ -173,6 +173,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1803",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/3B.json
+++ b/velbusaio/module_spec/3B.json
@@ -173,6 +173,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1803",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/3C.json
+++ b/velbusaio/module_spec/3C.json
@@ -173,6 +173,7 @@
     },
     "ModuleName": "03C0-03FF"
   },
+  "MemoryMapBuild": "1803",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/3D.json
+++ b/velbusaio/module_spec/3D.json
@@ -367,6 +367,7 @@
     },
     "ModuleName": "09BE-09FD"
   },
+  "MemoryMapBuild": "1803",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/3F.json
+++ b/velbusaio/module_spec/3F.json
@@ -14,5 +14,6 @@
   "Memory": {
     "ModuleName": "0000-003F"
   },
+  "MemoryMapBuild": "1948",
   "Type": "VMCM3"
 }

--- a/velbusaio/module_spec/40.json
+++ b/velbusaio/module_spec/40.json
@@ -14,5 +14,6 @@
   "Memory": {
     "ModuleName": "0000-003F"
   },
+  "MemoryMapBuild": "1948",
   "Type": "VMBUSBIP"
 }

--- a/velbusaio/module_spec/47.json
+++ b/velbusaio/module_spec/47.json
@@ -150,6 +150,7 @@
     },
     "ModuleName": "0678-06B7"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "light_value": {
       "Name": "Light value",

--- a/velbusaio/module_spec/4F.json
+++ b/velbusaio/module_spec/4F.json
@@ -174,6 +174,7 @@
     },
     "ModuleName": "06C0-06FF"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/50.json
+++ b/velbusaio/module_spec/50.json
@@ -174,6 +174,7 @@
     },
     "ModuleName": "06C0-06FF"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/51.json
+++ b/velbusaio/module_spec/51.json
@@ -174,6 +174,7 @@
     },
     "ModuleName": "06C0-06FF"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "selected_program": {
       "Name": "Selected program",

--- a/velbusaio/module_spec/52.json
+++ b/velbusaio/module_spec/52.json
@@ -331,6 +331,7 @@
     },
     "ModuleName": "0FA8-0FE7"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/53.json
+++ b/velbusaio/module_spec/53.json
@@ -150,6 +150,7 @@
     },
     "ModuleName": "0678-06B7"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "light_value": {
       "Name": "Light value",

--- a/velbusaio/module_spec/57.json
+++ b/velbusaio/module_spec/57.json
@@ -370,6 +370,7 @@
     },
     "ModuleName": "0FA8-0FE7"
   },
+  "MemoryMapBuild": "2346",
   "Properties": {
     "memo_text": {
       "Name": "Memo Text",

--- a/velbusaio/module_spec/5C.json
+++ b/velbusaio/module_spec/5C.json
@@ -150,6 +150,7 @@
     },
     "ModuleName": "0678-06B7"
   },
+  "MemoryMapBuild": "2320",
   "Properties": {
     "light_value": {
       "Name": "Light value",


### PR DESCRIPTION
Specs describe one particular memory map, but nothing said which one, and nothing checked whether the module in front of us actually uses it. This PR fixes the specs that matched no documented map, records the map each spec targets, and refuses to write to a module that predates it.

## The bug

Five specs sized their action table for a firmware build that predates the module name, while also declaring the module name that only exists in the later build. Those two layouts are mutually exclusive, so the last slots -- and for the relays the NO/NC contact byte -- addressed memory that belongs to the name.

Per the Velbus protocol documents, the newer maps shrank the table to make room for the name:

```
VMB4RYLD / VMB4RYNO / VMB1RYNO  (build 1409 or higher)
    39 -> 36 slots, NO/NC moved from bank+00EA to bank+00D8
VMBDMI   (build 1410 or higher)
VMBDMI-R (build 1915 or higher)
    37 -> 24 slots
```

The relay layout now matches VMB4RYLD-10 and VMB4RYNO-10, which already carried the corrected values.

Observed on a live bus before the fix: slot 38 of a VMB4RYLD reported an action from module address 101 on channel None. Those bytes were `65 6C 61 79 20 42` -- "elay B", characters 2 to 7 of the module name "Relay Boven 1". Writing was worse than reading: setting NO/NC would have written FF or 00 into character 8 of the name, and actions/set on slot 37 or 38 would have overwritten the name outright.

Those five are the complete set. Running the overlap test against the specs on master fails on exactly `10`, `11`, `15`, `1B` and `2F`.

## Recording which map a spec describes

The first version of this PR resolved the ambiguity by assuming modules run up-to-date firmware. That assumption is now replaced by a check.

Modules report their firmware build as year and week in DATABYTE6/7 of the module type message, which `vlp_reader` already compares as a `"YYWW"` string. The protocol documents head each memory map with the build it applies from:

```
Memory map version 1 (Build 1409 or higher):
Memory map version 1 for build 1415 or higher:
Memory map (build 0815):
Memory map 3 build 1948 or higher          (VMBSIG, no "version")
```

`MemoryMapBuild` records that build for the map each spec is written against, as a zero padded `"YYWW"` string. 47 of 97 specs get one; the rest are documents that describe a single map with no build stated, or none at all.

The build was chosen over the memory map version byte because every module reports its build, while eleven module types carry no version byte at all and the message layer substitutes a fixed 0 for them.

Two values do not come from the module's own document. The VMBEL1/2/4 document names the -20 types throughout and describes one map from build 2320, so `4F`/`50`/`51` take it; their `Memory` blocks are identical to `34`/`35`/`36`. VMBGPTC (`25`) is documented in the VMBGPO document, from build 1415.

VMB2BLE (`1D`) is stamped 1409 even though its document bounds that map at build 1809. Above it the layout is the one in VMB2BLE-10, whose spec declares a byte for byte identical `Memory` block, so the bound makes no difference to the addresses used here.

## Refusing to write

When the module is older than its spec's map, its eeprom is laid out differently and every address in the spec points somewhere else. Reading returns unrelated bytes; writing destroys whatever really lives there.

`Module.initialize` compares the two and records the outcome:

| | |
|---|---|
| `is_memory_map_outdated()` | the mismatch as state, so Home Assistant can show it on the device instead of it passing unnoticed in a log |
| `get_build()` | the module's build as `"YYWW"` |
| `get_memory_map_build()` | the build the spec was written against |

When the module is outdated its `MemoryBackend` is blocked and every `write_byte` and `write_bytes` raises `VelbusMemoryWriteBlocked`. Failing loudly is deliberate: a silent no-op would let Home Assistant believe a rename or an action table change succeeded. Reads stay allowed, since they are wrong but harmless, and blocking them would leave the device with no data at all.

Three cases deliberately stay quiet: the spec declares no build, the module reports none (restored from a cache or read from a vlp file), or the two are not comparable.

## Tests

`tests/module_spec_memory_test.py` walks every spec and asserts that the action table, NO/NC byte, channel names and module name never overlap. It handles both action-table shapes -- one table shared by all channels with the bank on the table, and one table per channel with the bank on the channel entry. An earlier version of the check only understood the second shape and silently skipped 51 of the 66 specs that declare a table.

`tests/module_memory_map_build_test.py` covers the comparison, the flag, the accessors and the write guard. The build is compared as a zero padded string; dropping the padding makes `test_one_week_older_warns` fail, because an unpadded `"148"` for year 14 week 8 compares as greater than `"1409"`.
