### PR TITLE
Refactor protocol/controller boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 requires-python = ">=3.13"
 dependencies = [
     "serialx",
-    "backoff>=1.10.0",
     "anyio",
     "beautifulsoup4",
     "lxml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 anyio
-backoff>=1.10.0
 beautifulsoup4
 lxml
 serialx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,15 +4,6 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-
-def pytest_configure(config):
-    """Filter third-party deprecation warnings that are not actionable here."""
-    config.addinivalue_line(
-        "filterwarnings",
-        "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:backoff.*",
-    )
-
-
 @pytest.fixture
 def mock_module():
     """Create a mock module for testing."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+
 @pytest.fixture
 def mock_module():
     """Create a mock module for testing."""

--- a/tests/memory_actions_test.py
+++ b/tests/memory_actions_test.py
@@ -260,7 +260,7 @@ class TestActionTable:
         from pathlib import Path
 
         spec = json.loads(
-            Path("velbusaio/module_spec/48.json").read_text(encoding="utf-8")
+            (Path(__file__).parents[1] / "velbusaio/module_spec/48.json").read_text(encoding="utf-8")
         )["Memory"]["ActionTable"]
         tables = build_action_tables(MemoryBackend(0x48, AsyncMock()), spec)
         assert tables[1].slot_count == 36

--- a/tests/module_status_test.py
+++ b/tests/module_status_test.py
@@ -87,7 +87,7 @@ async def test_module_status_selected_program(module_type):
             await m._properties["selected_program"].set_selected_program(
                 PROGRAM_SELECTION[program]
             )
-            msg_info = await velbus._protocol._send_queue.get()
+            msg_info = await velbus._send_queue.get()
             assert msg_info.data[1] == program
 
     # test GP4PIR lightvalue

--- a/tests/protocol_init_test.py
+++ b/tests/protocol_init_test.py
@@ -17,20 +17,16 @@ class TestVelbusProtocolInit:
         assert protocol._serial_buf == b""
         assert protocol.transport is None
         assert not protocol._closing
-        assert protocol._send_queue is not None
-        assert (
-            protocol._restart_writer is False
-        )  # Not started until transport connected
-        assert protocol._connection_state_callback is None
+        assert protocol._on_disconnect_callback is None
 
-    def test_init_with_connection_callback(self):
-        """Test protocol initialization with connection state callback."""
+    def test_init_with_disconnect_callback(self):
+        """Test protocol initialization with disconnect callback."""
         msg_callback = AsyncMock()
-        conn_callback = Mock()
-        protocol = VelbusProtocol(msg_callback, conn_callback)
+        disconnect_callback = Mock()
+        protocol = VelbusProtocol(msg_callback, on_disconnect_callback=disconnect_callback)
 
         assert protocol._message_received_callback == msg_callback
-        assert protocol._connection_state_callback == conn_callback
+        assert protocol._on_disconnect_callback == disconnect_callback
 
     def test_buffer_initialization(self):
         """Test that buffer is properly initialized."""

--- a/tests/protocol_writing_test.py
+++ b/tests/protocol_writing_test.py
@@ -138,3 +138,32 @@ class TestVelbusProtocolWriting:
         velbus._send_queue.task_done()
 
         await asyncio.wait_for(velbus.wait_on_all_messages_sent_async(), timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_send_loop_retry_on_disconnect(self):
+        """Test that send loop retries sending a message if connection drops before sending."""
+        velbus = Velbus("")
+        mock_protocol = Mock()
+        mock_protocol.is_connected = False
+        mock_protocol.wait_can_write = AsyncMock()
+
+        send_task = asyncio.create_task(velbus._send_loop())
+
+        mock_msg = Mock()
+        mock_msg.rtr = False
+        mock_msg.command = 0x01
+        await velbus._send_queue.put(mock_msg)
+
+        await asyncio.sleep(0.05)
+        assert velbus._send_queue.qsize() == 1
+
+        velbus._protocol = mock_protocol
+        mock_protocol.write_message.return_value = True
+        velbus._is_connected = True
+        mock_protocol.is_connected = True
+        velbus._connected_event.set()
+
+        await asyncio.wait_for(velbus.wait_on_all_messages_sent_async(), timeout=1.0)
+
+        mock_protocol.write_message.assert_called_once_with(mock_msg)
+        await velbus.stop()

--- a/tests/protocol_writing_test.py
+++ b/tests/protocol_writing_test.py
@@ -167,3 +167,45 @@ class TestVelbusProtocolWriting:
 
         mock_protocol.write_message.assert_called_once_with(mock_msg)
         await velbus.stop()
+
+    @pytest.mark.asyncio
+    async def test_connect_aborted_on_stop(self):
+        """Test that connect() aborts cleanly if stop() is called while connecting."""
+        from unittest.mock import patch
+
+        velbus = Velbus("tcp://127.0.0.1:3788")
+        mock_protocol = Mock()
+
+        async def mock_create_connection(*args, **kwargs):
+            await velbus.stop()
+            return (Mock(), mock_protocol)
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.create_connection = AsyncMock(
+                side_effect=mock_create_connection
+            )
+            await velbus.connect()
+
+        assert not velbus.connected
+        mock_protocol.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_after_stop(self):
+        """Test that connect() works when called after stop()."""
+        from unittest.mock import patch
+
+        velbus = Velbus("tcp://127.0.0.1:3788")
+        mock_protocol = Mock()
+
+        await velbus.stop()
+        assert velbus._closing
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.create_connection = AsyncMock(
+                return_value=(Mock(), mock_protocol)
+            )
+            await velbus.connect()
+
+        assert velbus.connected
+        assert not velbus._closing
+        await velbus.stop()

--- a/tests/protocol_writing_test.py
+++ b/tests/protocol_writing_test.py
@@ -147,7 +147,7 @@ class TestVelbusProtocolWriting:
         mock_protocol.is_connected = False
         mock_protocol.wait_can_write = AsyncMock()
 
-        send_task = asyncio.create_task(velbus._send_loop())
+        asyncio.create_task(velbus._send_loop())
 
         mock_msg = Mock()
         mock_msg.rtr = False

--- a/tests/protocol_writing_test.py
+++ b/tests/protocol_writing_test.py
@@ -1,74 +1,18 @@
 """Test cases for VelbusProtocol writing functionality"""
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from velbusaio.controller import Velbus
 from velbusaio.protocol import VelbusProtocol
 
 
 class TestVelbusProtocolWriting:
-    """Test cases for writing and pause/restart functionality."""
+    """Test cases for writing functionality."""
 
-    @pytest.mark.asyncio
-    async def test_pause_writing(self):
-        """Test pausing writing."""
-        callback = AsyncMock()
-        protocol = VelbusProtocol(callback)
-
-        protocol._restart_writer = True
-        protocol._writer_task = Mock()
-
-        protocol.pause_writing()
-
-        assert protocol._restart_writer is False
-
-    @pytest.mark.asyncio
-    async def test_restart_writing(self):
-        """Test restarting writing."""
-        callback = AsyncMock()
-        protocol = VelbusProtocol(callback)
-
-        protocol._restart_writer = True
-        protocol.restart_writing()
-
-        assert protocol._writer_task is not None
-        assert not protocol._writer_task.done()
-
-        protocol.pause_writing()
-        await asyncio.wait_for(protocol._writer_task, timeout=1.0)
-
-    def test_restart_writing_when_locked(self):
-        """Test restarting writing when lock is held."""
-        callback = AsyncMock()
-        protocol = VelbusProtocol(callback)
-
-        protocol._restart_writer = True
-        protocol._write_transport_lock._locked = True
-
-        with patch("asyncio.ensure_future") as mock_ensure_future:
-            protocol.restart_writing()
-
-            # Should not restart when locked
-            mock_ensure_future.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_send_message(self):
-        """Test sending a message."""
-        callback = AsyncMock()
-        protocol = VelbusProtocol(callback)
-
-        mock_message = Mock()
-        mock_message.to_bytes.return_value = b"\x0f\x01"
-
-        await protocol.send_message(mock_message)
-
-        # Message should be in queue
-        assert protocol._send_queue.qsize() == 1
-
-    @pytest.mark.asyncio
-    async def test_write_message_success(self):
+    def test_write_message_success(self):
         """Test writing a message successfully."""
         callback = AsyncMock()
         protocol = VelbusProtocol(callback)
@@ -80,13 +24,12 @@ class TestVelbusProtocolWriting:
         mock_message = Mock()
         mock_message.to_bytes.return_value = b"\x0f\x01\x02"
 
-        result = await protocol._write_message(mock_message)
+        result = protocol.write_message(mock_message)
 
         assert result is True
         mock_transport.write.assert_called_once_with(b"\x0f\x01\x02")
 
-    @pytest.mark.asyncio
-    async def test_write_message_transport_closing(self):
+    def test_write_message_transport_closing(self):
         """Test writing a message when transport is closing."""
         callback = AsyncMock()
         protocol = VelbusProtocol(callback)
@@ -97,26 +40,46 @@ class TestVelbusProtocolWriting:
 
         mock_message = Mock()
 
-        # Call the undecorated implementation to avoid the backoff retry
-        # decorator, which would otherwise cause the test to wait.
-        result = await protocol._write_message.__wrapped__(protocol, mock_message)
+        result = protocol.write_message(mock_message)
 
         assert result is False
         mock_transport.write.assert_not_called()
 
+    def test_connection_made_sends_auth_key(self):
+        """Test automatic authentication key transmission when connection is established."""
+        callback = AsyncMock()
+        protocol = VelbusProtocol(callback, auth_key="test_key_123")
+
+        mock_transport = Mock()
+        protocol.connection_made(mock_transport)
+
+        mock_transport.write.assert_called_once_with(b"test_key_123")
+
+    def test_connection_made_without_auth_key(self):
+        """Test no authentication key transmitted on connection_made when auth_key is None."""
+        callback = AsyncMock()
+        protocol = VelbusProtocol(callback, auth_key=None)
+
+        mock_transport = Mock()
+        protocol.connection_made(mock_transport)
+
+        mock_transport.write.assert_not_called()
+
     @pytest.mark.asyncio
-    async def test_write_auth_key(self):
-        """Test writing authentication key."""
+    async def test_flow_control_pause_resume(self):
+        """Test pause_writing and resume_writing flow control events."""
         callback = AsyncMock()
         protocol = VelbusProtocol(callback)
 
         mock_transport = Mock()
-        mock_transport.is_closing.return_value = False
-        protocol.transport = mock_transport
+        protocol.connection_made(mock_transport)
+        assert protocol._can_write.is_set()
 
-        await protocol.write_auth_key("test_key_123")
+        protocol.pause_writing()
+        assert not protocol._can_write.is_set()
 
-        mock_transport.write.assert_called_once_with(b"test_key_123")
+        protocol.resume_writing()
+        assert protocol._can_write.is_set()
 
     def test_calculate_queue_sleep_time_normal(self):
         """Test calculating sleep time for normal message."""
@@ -124,7 +87,7 @@ class TestVelbusProtocolWriting:
         mock_message.rtr = False
         mock_message.command = 0x01
 
-        sleep_time = VelbusProtocol._calculate_queue_sleep_time(mock_message, 0.001)
+        sleep_time = Velbus._calculate_queue_sleep_time(mock_message, 0.001)
 
         assert sleep_time > 0
 
@@ -136,7 +99,7 @@ class TestVelbusProtocolWriting:
         mock_message.rtr = True
         mock_message.command = 0x01
 
-        sleep_time = VelbusProtocol._calculate_queue_sleep_time(mock_message, 0.001)
+        sleep_time = Velbus._calculate_queue_sleep_time(mock_message, 0.001)
 
         assert sleep_time >= SLEEP_TIME - 0.001
 
@@ -148,9 +111,8 @@ class TestVelbusProtocolWriting:
         mock_message.rtr = False
         mock_message.command = 0xEF
 
-        sleep_time = VelbusProtocol._calculate_queue_sleep_time(mock_message, 0.001)
+        sleep_time = Velbus._calculate_queue_sleep_time(mock_message, 0.001)
 
-        # Should be longer for channel name request
         assert sleep_time >= SLEEP_TIME * 33 - 0.001
 
     def test_calculate_queue_sleep_time_already_late(self):
@@ -161,7 +123,7 @@ class TestVelbusProtocolWriting:
         mock_message.rtr = False
         mock_message.command = 0x01
 
-        sleep_time = VelbusProtocol._calculate_queue_sleep_time(
+        sleep_time = Velbus._calculate_queue_sleep_time(
             mock_message, SLEEP_TIME + 1
         )
 
@@ -169,13 +131,10 @@ class TestVelbusProtocolWriting:
 
     @pytest.mark.asyncio
     async def test_wait_on_all_messages_sent_async(self):
-        """Test waiting for all messages to be sent."""
-        callback = AsyncMock()
-        protocol = VelbusProtocol(callback)
+        """Test waiting for all messages to be sent in controller."""
+        velbus = Velbus("")
 
-        # Add a message and immediately mark as done
-        await protocol._send_queue.put(Mock())
-        protocol._send_queue.task_done()
+        await velbus._send_queue.put(Mock())
+        velbus._send_queue.task_done()
 
-        # Should complete without hanging
-        await asyncio.wait_for(protocol.wait_on_all_messages_sent_async(), timeout=1.0)
+        await asyncio.wait_for(velbus.wait_on_all_messages_sent_async(), timeout=1.0)

--- a/tests/protocol_writing_test.py
+++ b/tests/protocol_writing_test.py
@@ -209,3 +209,20 @@ class TestVelbusProtocolWriting:
         assert velbus.connected
         assert not velbus._closing
         await velbus.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_background_tasks(self):
+        """Test that stop() cancels all running tasks in _background_tasks."""
+        velbus = Velbus("")
+
+        async def dummy_background_task():
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(dummy_background_task())
+        velbus._background_tasks.add(task)
+        task.add_done_callback(velbus._background_tasks.discard)
+
+        await velbus.stop()
+
+        assert task.cancelled() or task.done()
+        assert len(velbus._background_tasks) == 0

--- a/tests/thermostat_operating_mode_test.py
+++ b/tests/thermostat_operating_mode_test.py
@@ -54,7 +54,7 @@ async def test_thermostat_operating_mode(mode, sleep_timer):
     assert m._channels[chan]._sleep_timer == sleep_timer
 
     await m._channels[chan].set_climate_mode(DSTATUS[mode])
-    msg_info = await velbus._protocol._send_queue.get()
+    msg_info = await velbus._send_queue.get()
     check_sleep_timer = (msg_info.data[1] << 8) + msg_info.data[2]
     if DSTATUS[mode] == "run":
         sleep = 0x0

--- a/uv.lock
+++ b/uv.lock
@@ -15,15 +15,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -161,11 +152,10 @@ wheels = [
 
 [[package]]
 name = "velbus-aio"
-version = "2026.7.26"
+version = "2026.7.25"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "backoff" },
     { name = "beautifulsoup4" },
     { name = "lxml" },
     { name = "serialx" },
@@ -174,7 +164,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anyio" },
-    { name = "backoff", specifier = ">=1.10.0" },
     { name = "beautifulsoup4" },
     { name = "lxml" },
     { name = "serialx" },

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -97,7 +97,7 @@ class Velbus:
         self._destination = dsn
         self._send_queue: asyncio.Queue = asyncio.Queue()
         self._connected_event: asyncio.Event = asyncio.Event()
-        self._protocol: VelbusProtocol = self.__protocol_factory()
+        self._protocol: VelbusProtocol | None = None
         self._send_task: asyncio.Task | None = None
         self._handler = PacketHandler(self, one_address)
         self._modules: dict[int, Module] = {}

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -141,34 +141,38 @@ class Velbus:
 
                 msg_info: RawMessage = await self._send_queue.get()
                 try:
-                    while not self._closing and not (
-                        self._is_connected
-                        and self._protocol
-                        and self._protocol.is_connected
-                    ):
+                    message_sent = False
+                    while not message_sent and not self._closing:
                         await self._connected_event.wait()
+                        if self._closing:
+                            break
 
-                    if self._closing:
-                        break
+                        if not (
+                            self._is_connected
+                            and self._protocol
+                            and self._protocol.is_connected
+                        ):
+                            continue
 
-                    if self._protocol:
                         await self._protocol.wait_can_write()
 
-                    # Re-verify connection and closing state after wait_can_write
-                    if self._closing or not (
-                        self._is_connected
-                        and self._protocol
-                        and self._protocol.is_connected
-                    ):
-                        continue
+                        # Re-verify connection and closing state after wait_can_write
+                        if self._closing or not (
+                            self._is_connected
+                            and self._protocol
+                            and self._protocol.is_connected
+                        ):
+                            continue
 
-                    start_time = time.monotonic()
-                    self._protocol.write_message(msg_info)
-                    send_time = time.monotonic() - start_time
-
-                    sleep_time = self._calculate_queue_sleep_time(msg_info, send_time)
-                    if sleep_time > 0 and not self._closing:
-                        await asyncio.sleep(sleep_time)
+                        start_time = time.monotonic()
+                        message_sent = self._protocol.write_message(msg_info)
+                        if message_sent:
+                            send_time = time.monotonic() - start_time
+                            sleep_time = self._calculate_queue_sleep_time(
+                                msg_info, send_time
+                            )
+                            if sleep_time > 0 and not self._closing:
+                                await asyncio.sleep(sleep_time)
                 finally:
                     self._send_queue.task_done()
             except asyncio.CancelledError:

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -177,7 +177,7 @@ class Velbus:
                     self._send_queue.task_done()
             except asyncio.CancelledError:
                 break
-            except Exception:
+            except Exception:  # noqa: BLE001
                 self._log.exception("Error in Velbus send loop")
         self._log.debug("Ending Velbus send loop")
 
@@ -351,7 +351,7 @@ class Velbus:
         return VelbusProtocol(
             message_received_callback=self._on_message_received,
             on_disconnect_callback=self._on_disconnect,
-            auth_key=dest_parts.username if dest_parts.username else None,
+            auth_key=dest_parts.username or None,
         )
 
     async def connect(self) -> None:

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -329,6 +329,12 @@ class Velbus:
         # Stop all scheduled tasks
         for task in self._scheduled_tasks.values():
             task.stop()
+        for task in list(self._background_tasks):
+            if not task.done():
+                task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*list(self._background_tasks), return_exceptions=True)
+        self._background_tasks.clear()
         if self._protocol:
             self._protocol.close()
 

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -350,9 +350,13 @@ class Velbus:
 
     async def connect(self) -> None:
         """Connect to the bus and load all the data."""
+        self._closing = False
+        self._auto_reconnect = True
         if self._send_task is None or self._send_task.done():
             self._send_task = asyncio.create_task(self._send_loop())
         await self._handler.read_protocol_data()
+        if self._closing:
+            return
         # connect to the bus
         destination = self._destination
         has_scheme = bool(re.search(r"^[A-Za-z0-9+.\-]+://", destination))
@@ -390,6 +394,10 @@ class Velbus:
                 )
             except (ConnectionRefusedError, OSError) as err:
                 raise VelbusConnectionFailed from err
+            if self._closing:
+                if self._protocol:
+                    self._protocol.close()
+                return
             await self._on_connection_state(True)
             return
 
@@ -411,6 +419,10 @@ class Velbus:
             )
         except (FileNotFoundError, serialx.SerialException) as err:
             raise VelbusConnectionFailed from err
+        if self._closing:
+            if self._protocol:
+                self._protocol.close()
+            return
         await self._on_connection_state(True)
 
     async def start(self) -> None:

--- a/velbusaio/controller.py
+++ b/velbusaio/controller.py
@@ -27,6 +27,7 @@ from velbusaio.channels import (
     Temperature,
 )
 from velbusaio.config import ConfigParameter
+from velbusaio.const import SLEEP_TIME
 from velbusaio.exceptions import VelbusConnectionFailed
 from velbusaio.handler import PacketHandler
 from velbusaio.helpers import get_cache_dir
@@ -90,19 +91,17 @@ class Velbus:
     ) -> None:
         """Init the Velbus controller."""
         self._log = logging.getLogger("velbus")
-
-        self._protocol = VelbusProtocol(
-            message_received_callback=self._on_message_received,
-            connection_state_callback=self._on_connection_state,
-        )
         self._closing = False
         self._auto_reconnect = True
 
         self._destination = dsn
+        self._send_queue: asyncio.Queue = asyncio.Queue()
+        self._connected_event: asyncio.Event = asyncio.Event()
+        self._protocol: VelbusProtocol = self.__protocol_factory()
+        self._send_task: asyncio.Task | None = None
         self._handler = PacketHandler(self, one_address)
         self._modules: dict[int, Module] = {}
         self._submodules: list[int] = []
-        self._send_queue: asyncio.Queue = asyncio.Queue()
         self._vlp_file = vlp_file
         self._cache_dir: str = cache_dir
         self._is_connected: bool = False
@@ -114,6 +113,69 @@ class Velbus:
         self._background_tasks: set[asyncio.Task] = set()
         self._scheduled_tasks: dict[str, ScheduledTask] = {}
         self._scheduler_log = logging.getLogger("velbus-scheduler")
+
+    @staticmethod
+    def _calculate_queue_sleep_time(msg_info, send_time):
+        """Calculate the sleep time needed after sending a message to Velbus."""
+        sleep_time = SLEEP_TIME
+
+        if msg_info.rtr:
+            sleep_time = SLEEP_TIME  # this is a scan command. We could be quicker?
+
+        if msg_info.command == 0xEF:
+            # 'channel name request' command provokes in worst case 99 answer packets from VMBGPOD
+            sleep_time = SLEEP_TIME * 33  # TODO make this adaptable on module_type
+
+        if send_time > sleep_time:
+            return 0  # no need to wait, we are already late
+        return sleep_time - send_time
+
+    async def _send_loop(self) -> None:
+        """Outbound queue loop that dispatches messages when connected."""
+        self._log.debug("Starting Velbus send loop")
+        while not self._closing:
+            try:
+                await self._connected_event.wait()
+                if self._closing:
+                    break
+
+                msg_info: RawMessage = await self._send_queue.get()
+                try:
+                    while not self._closing and not (
+                        self._is_connected
+                        and self._protocol
+                        and self._protocol.is_connected
+                    ):
+                        await self._connected_event.wait()
+
+                    if self._closing:
+                        break
+
+                    if self._protocol:
+                        await self._protocol.wait_can_write()
+
+                    # Re-verify connection and closing state after wait_can_write
+                    if self._closing or not (
+                        self._is_connected
+                        and self._protocol
+                        and self._protocol.is_connected
+                    ):
+                        continue
+
+                    start_time = time.monotonic()
+                    self._protocol.write_message(msg_info)
+                    send_time = time.monotonic() - start_time
+
+                    sleep_time = self._calculate_queue_sleep_time(msg_info, send_time)
+                    if sleep_time > 0 and not self._closing:
+                        await asyncio.sleep(sleep_time)
+                finally:
+                    self._send_queue.task_done()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                self._log.exception("Error in Velbus send loop")
+        self._log.debug("Ending Velbus send loop")
 
     def add_connect_callback(self, meth: t.Callable[[], Awaitable[None]]) -> None:
         """Register a coroutine to be called on connect."""
@@ -173,9 +235,11 @@ class Velbus:
         """Respond to Protocol connection state changes."""
         self._is_connected = is_connected
         if is_connected:
+            self._connected_event.set()
             for callback in self._on_connect_callbacks:
                 await callback()
         else:
+            self._connected_event.clear()
             for callback in self._on_disconnect_callbacks:
                 await callback()
             if self._auto_reconnect and not self._closing:
@@ -255,13 +319,35 @@ class Velbus:
         """Stop the controller."""
         self._closing = True
         self._auto_reconnect = False
+        self._connected_event.set()
+        if self._send_task and not self._send_task.done():
+            self._send_task.cancel()
         # Stop all scheduled tasks
         for task in self._scheduled_tasks.values():
             task.stop()
-        self._protocol.close()
+        if self._protocol:
+            self._protocol.close()
+
+    def _on_disconnect(self, exc: Exception | None) -> None:
+        """Handle protocol disconnect callback synchronously from protocol."""
+        task = asyncio.ensure_future(self._on_connection_state(False))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def __protocol_factory(self) -> VelbusProtocol:
+        """Create a new protocol instance for a new connection."""
+
+        dest_parts = urlparse(self._destination)
+        return VelbusProtocol(
+            message_received_callback=self._on_message_received,
+            on_disconnect_callback=self._on_disconnect,
+            auth_key=dest_parts.username if dest_parts.username else None,
+        )
 
     async def connect(self) -> None:
         """Connect to the bus and load all the data."""
+        if self._send_task is None or self._send_task.done():
+            self._send_task = asyncio.create_task(self._send_loop())
         await self._handler.read_protocol_data()
         # connect to the bus
         destination = self._destination
@@ -291,25 +377,26 @@ class Velbus:
             try:
                 (
                     _transport,
-                    _protocol,
+                    self._protocol,
                 ) = await asyncio.get_running_loop().create_connection(
-                    lambda: self._protocol,
+                    self.__protocol_factory,
                     host=parts.hostname,
                     port=parts.port,
                     ssl=ctx,
                 )
             except (ConnectionRefusedError, OSError) as err:
                 raise VelbusConnectionFailed from err
+            await self._on_connection_state(True)
             return
 
         # serial and serialx-backed schemes (e.g. /dev/..., esphome://...)
         try:
             (
                 _serial_transport,
-                _serial_protocol,
+                self._protocol,
             ) = await serialx.create_serial_connection(
                 asyncio.get_running_loop(),
-                t.cast("t.Callable[[], asyncio.Protocol]", lambda: self._protocol),
+                self.__protocol_factory,
                 url=destination,
                 baudrate=38400,
                 byte_size=serialx.EIGHTBITS,
@@ -320,13 +407,10 @@ class Velbus:
             )
         except (FileNotFoundError, serialx.SerialException) as err:
             raise VelbusConnectionFailed from err
+        await self._on_connection_state(True)
 
     async def start(self) -> None:
         """Start the controller."""
-        # if auth is required send the auth key
-        parts = urlparse(self._destination)
-        if parts.username:
-            await self._protocol.write_auth_key(parts.username)
 
         if self._vlp_file:
             # use the vlp file to load the modules
@@ -373,7 +457,7 @@ class Velbus:
 
     async def send(self, msg: Message) -> None:
         """Send a packet."""
-        await self._protocol.send_message(
+        self._send_queue.put_nowait(
             RawMessage(
                 priority=msg.priority,
                 address=msg.address,
@@ -500,7 +584,7 @@ class Velbus:
 
     async def wait_on_all_messages_sent_async(self) -> None:
         """Wait for all messages to be sent."""
-        await self._protocol.wait_on_all_messages_sent_async()
+        await self._send_queue.join()
 
     def add_scheduled_task(
         self,

--- a/velbusaio/protocol.py
+++ b/velbusaio/protocol.py
@@ -68,12 +68,14 @@ class VelbusProtocol(asyncio.BufferedProtocol):
     def connection_made(self, transport: transports.BaseTransport) -> None:
         """Called when the Velbus connection is established."""
         self.transport = t.cast("asyncio.Transport", transport)
-        self._can_write.set()
         self._log.info("Connection established to Velbus")
 
         if self._auth_key:
             self._log.debug("TX: authentication key")
             self.transport.write(self._auth_key.encode("utf-8"))
+
+        # After sending the auth_key, we can write again.
+        self._can_write.set()
 
         self._last_activity_time = time.time()
 

--- a/velbusaio/protocol.py
+++ b/velbusaio/protocol.py
@@ -9,97 +9,87 @@ import logging
 import time
 import typing as t
 
-import backoff
-
-from velbusaio.const import MAXIMUM_MESSAGE_SIZE, MINIMUM_MESSAGE_SIZE, SLEEP_TIME
+from velbusaio.const import MAXIMUM_MESSAGE_SIZE, MINIMUM_MESSAGE_SIZE
 from velbusaio.message import ParserError
 from velbusaio.raw_message import RawMessage, create as create_message_info
 
 
 class VelbusProtocol(asyncio.BufferedProtocol):
-    """Handles the Velbus protocol.
-
-    This class is expected to be wrapped inside a VelbusConnection class object which will maintain the socket
-    and handle auto-reconnects
-    """
+    """Handles the Velbus protocol framing and transport I/O."""
 
     def __init__(
         self,
         message_received_callback: t.Callable[[RawMessage], t.Awaitable[None]],
-        connection_state_callback: t.Callable[[bool], t.Awaitable[None]] | None = None,
+        on_disconnect_callback: t.Callable[[Exception | None], None] | None = None,
+        auth_key: str | None = None,
     ) -> None:
         """Initialize VelbusProtocol with callbacks."""
         super().__init__()
         self._log = logging.getLogger("velbus-protocol")
         self._message_received_callback = message_received_callback
-        self._connection_state_callback = connection_state_callback
+        self._on_disconnect_callback = on_disconnect_callback
+        self._auth_key: str | None = auth_key
 
-        # everything for reading from Velbus
+        # Everything for reading from Velbus
+
         # _buffer is a fixed scratch buffer the transport writes into on the
         # BufferedProtocol (get_buffer/buffer_updated) read path. buffer_updated()
         # copies the received bytes into _serial_buf, so both read paths converge
         # on the same framing logic in data_received().
         self._buffer = bytearray(MAXIMUM_MESSAGE_SIZE)
         self._buffer_view = memoryview(self._buffer)
-
         self._serial_buf = b""
         self.transport: asyncio.Transport | None = None
+        self._last_activity_time: float = time.time()
 
-        # everything for writing to Velbus
-        self._send_queue: asyncio.Queue = asyncio.Queue()
-        self._write_transport_lock = asyncio.Lock()
-        self._writer_task: asyncio.Task | None = None
-        self._restart_writer = False
-        self.restart_writing()
-
+        # Flow control
+        self._can_write: asyncio.Event = asyncio.Event()
         self._closing = False
-        self._background_tasks = set()
 
-    def _notify_connection_state_callbacks(self, is_connected: bool) -> None:
-        """Notify all registered callbacks of connection state change."""
-        if self._connection_state_callback is None:
-            return
-        task = asyncio.ensure_future(self._connection_state_callback(is_connected))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+    @property
+    def is_connected(self) -> bool:
+        """Return whether transport is active and connected."""
+        return self.transport is not None and not self.transport.is_closing()
+
+    def pause_writing(self) -> None:
+        """Called when transport output buffer exceeds high watermark."""
+        self._can_write.clear()
+        self._log.debug("Transport write paused (high watermark reached)")
+
+    def resume_writing(self) -> None:
+        """Called when transport output buffer drains below low watermark."""
+        self._can_write.set()
+        self._log.debug("Transport write resumed (low watermark reached)")
+
+    async def wait_can_write(self) -> None:
+        """Wait until transport is ready to accept writes."""
+        await self._can_write.wait()
 
     def connection_made(self, transport: transports.BaseTransport) -> None:
         """Called when the Velbus connection is established."""
         self.transport = t.cast("asyncio.Transport", transport)
+        self._can_write.set()
         self._log.info("Connection established to Velbus")
+
+        if self._auth_key:
+            self._log.debug("TX: authentication key")
+            self.transport.write(self._auth_key.encode("utf-8"))
+
         self._last_activity_time = time.time()
-
-        self._restart_writer = True
-        self.restart_writing()
-
-        # Notify callbacks that connection is established
-        self._notify_connection_state_callbacks(True)
-
-    def pause_writing(self) -> None:
-        """Pause writing."""
-        self._restart_writer = False
-        if self._writer_task:
-            self._send_queue.put_nowait(None)
-
-    def restart_writing(self) -> None:
-        """Resume writing."""
-        if self._restart_writer and not self._write_transport_lock.locked():
-            self._writer_task = asyncio.ensure_future(
-                self._get_message_from_send_queue()
-            )
-            self._writer_task.add_done_callback(lambda _future: self.restart_writing())
 
     def close(self) -> None:
         """Close the Velbus connection."""
         self._closing = True
-        self._restart_writer = False
+
+        # By setting _can_write here, we prevent deadlocks in the controller.
+        self._can_write.set()
         if self.transport:
             self.transport.close()
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Called when the Velbus connection is lost."""
         self.transport = None
-        self.pause_writing()
+        self._can_write.set()
 
         if self._closing:
             return  # Connection loss was expected, nothing to do here...
@@ -108,9 +98,10 @@ class VelbusProtocol(asyncio.BufferedProtocol):
         else:
             self._log.error(f"Velbus connection lost: {exc!r}")
 
-        self._notify_connection_state_callbacks(False)
+        if self._on_disconnect_callback is not None:
+            self._on_disconnect_callback(exc)
 
-    # Everything read-related
+    # Read Path
 
     def get_buffer(self, sizehint: int) -> memoryview:
         """Provide a writable buffer for the BufferedProtocol read path.
@@ -178,85 +169,13 @@ class VelbusProtocol(asyncio.BufferedProtocol):
         except ParserError as exc:
             self._log.warning(f"Dropping unparsable message ({exc}): {msg}")
 
-    # Everything write-related
+    # Write Path
 
-    async def write_auth_key(self, authkey: str) -> None:
-        """Send authentication key to Velbus interface."""
-        self._log.debug("TX: authentication key")
-        if self.transport is not None and not self.transport.is_closing():
-            self.transport.write(authkey.encode("utf-8"))
-
-    async def send_message(self, msg: RawMessage) -> None:
-        """Queue a message to be sent to Velbus."""
-        self._send_queue.put_nowait(msg)
-
-    async def _get_message_from_send_queue(self) -> None:
-        """Get messages from the send queue and write them to Velbus."""
-        self._log.debug("Starting Velbus write message from send queue")
-        self._log.debug("Acquiring write lock")
-        await self._write_transport_lock.acquire()
-        while self._restart_writer:
-            # wait for an item from the queue
-            msg_info: RawMessage | None = await self._send_queue.get()
-            if msg_info is None:
-                self._restart_writer = False
-                if self._write_transport_lock.locked():
-                    self._write_transport_lock.release()
-                return
-            message_sent = False
-            try:
-                start_time = time.perf_counter()
-                while not message_sent:
-                    message_sent = await self._write_message(msg_info)
-                send_time = time.perf_counter() - start_time
-
-                self._send_queue.task_done()  # indicate that the item of the queue has been processed
-
-                queue_sleep_time = self._calculate_queue_sleep_time(msg_info, send_time)
-                await asyncio.sleep(queue_sleep_time)
-
-            except (asyncio.CancelledError, GeneratorExit) as exc:
-                if not self._closing:
-                    self._log.error(f"Stopping Velbus writer due to {exc!r}")
-                self._restart_writer = False
-            except (OSError, RuntimeError) as exc:
-                self._log.error(f"Restarting Velbus writer due to {exc!r}")
-                self._restart_writer = True
-        if self._write_transport_lock.locked():
-            self._write_transport_lock.release()
-        self._log.debug("Ending Velbus write message from send queue")
-
-    @staticmethod
-    def _calculate_queue_sleep_time(msg_info, send_time):
-        """Calculate the sleep time needed after sending a message to Velbus."""
-        sleep_time = SLEEP_TIME
-
-        if msg_info.rtr:
-            sleep_time = SLEEP_TIME  # this is a scan command. We could be quicker?
-
-        if msg_info.command == 0xEF:
-            # 'channel name request' command provokes in worst case 99 answer packets from VMBGPOD
-            sleep_time = SLEEP_TIME * 33  # TODO make this adaptable on module_type
-
-        if send_time > sleep_time:
-            return 0  # no need to wait, we are already late
-        return sleep_time - send_time
-
-    @backoff.on_predicate(
-        backoff.expo,
-        lambda is_sent: not is_sent,
-        max_tries=10,
-    )
-    async def _write_message(self, msg: RawMessage) -> bool:
-        """Write a message to Velbus."""
+    def write_message(self, msg: RawMessage) -> bool:
+        """Write a raw message to the Velbus transport."""
         self._log.debug(f"TX: {msg}")
         if self.transport and not self.transport.is_closing():
             self.transport.write(msg.to_bytes())
             self._last_activity_time = time.time()
             return True
         return False
-
-    async def wait_on_all_messages_sent_async(self) -> None:
-        """Wait until all messages in the send queue are sent."""
-        self._log.debug("Waiting on all messages sent")
-        await self._send_queue.join()


### PR DESCRIPTION
While fixing #199 , I had a hard time understanding the separation of concern between the `Velbus` controller and the `VelbusProtocol`. As I introduced the Protocol in the first place (#11) , I also feel a bit responsible for cleaning this up.

### Summary of Changes

* **Controller & Protocol Separation of Concerns:**
  * Moved outbound message queuing (`_send_queue`) and inter-frame rate-limiting logic from `VelbusProtocol` into the `Velbus` controller.
  * Streamlined `VelbusProtocol` to focus exclusively on low-level transport I/O, byte stream framing, and message parsing.

* **Flow Control & Authentication:**
  * Implemented transport write buffer flow control (`pause_writing` / `resume_writing`) in `VelbusProtocol` to prevent buffer overflow.
  * Integrated authentication key transmission into `connection_made` before opening the transport for outbound writes.

* **Cleanup & Testing:**
  * Removed `backoff` dependency (retries are now handled in `_send_loop`).
  * Added unit tests for flow control, message retry on disconnect, and controller lifecycle/shutdown edge cases.