### PR TITLE
Add is_gas/is_electricity helpers and return HA-valid counter units

### DIFF
--- a/tests/channel_buttoncounter_test.py
+++ b/tests/channel_buttoncounter_test.py
@@ -241,6 +241,29 @@ class TestButtonCounter:
         button._Unit = ENERGY_KILO_WATT_HOUR
         assert not button.is_water()
 
+    def test_is_gas(self, mock_module, mock_writer):
+        """Test checking if counter is gas meter."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._counter = 100
+        button._Unit = VOLUME_CUBIC_METER_HOUR
+        assert button.is_gas()
+
+        button._Unit = ENERGY_KILO_WATT_HOUR
+        assert not button.is_gas()
+
+    def test_is_electricity(self, mock_module, mock_writer):
+        """Test checking if counter is electricity meter."""
+        button = ButtonCounter(
+            mock_module, 1, "Counter", False, True, mock_writer, 0x01
+        )
+        button._Unit = ENERGY_KILO_WATT_HOUR
+        assert button.is_electricity()
+
+        button._Unit = VOLUME_LITERS_HOUR
+        assert not button.is_electricity()
+
     def test_energy_from_energy_field(self, mock_module, mock_writer):
         """Test energy property returns kWh from _energy field (Wh)."""
         button = ButtonCounter(

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -645,11 +645,11 @@ class ButtonCounter(Button):
         return self._rate_from_pulse_interval()
 
     def get_unit(self) -> str | None:
-        """Return the unit of the counter."""
+        """Return the unit of the instantaneous value."""
         if self._Unit == VOLUME_LITERS_HOUR:
-            return "L"
+            return "L/h"
         if self._Unit == VOLUME_CUBIC_METER_HOUR:
-            return "m3"
+            return "m³/h"
         if self._Unit == ENERGY_KILO_WATT_HOUR:
             return "W"
         return None
@@ -676,6 +676,14 @@ class ButtonCounter(Button):
     def is_water(self) -> bool:
         """Return if this channel is a water channel."""
         return bool(self._counter and self._Unit == VOLUME_LITERS_HOUR)
+
+    def is_gas(self) -> bool:
+        """Return if this channel is a gas channel."""
+        return bool(self._counter and self._Unit == VOLUME_CUBIC_METER_HOUR)
+
+    def is_electricity(self) -> bool:
+        """Return if this channel is an electricity channel."""
+        return self._Unit == ENERGY_KILO_WATT_HOUR
 
 
 class Sensor(Button):

--- a/velbusaio/channels.py
+++ b/velbusaio/channels.py
@@ -645,11 +645,11 @@ class ButtonCounter(Button):
         return self._rate_from_pulse_interval()
 
     def get_unit(self) -> str | None:
-        """Return the unit of the instantaneous value."""
+        """Return the unit of the counter."""
         if self._Unit == VOLUME_LITERS_HOUR:
-            return "L/h"
+            return "L"
         if self._Unit == VOLUME_CUBIC_METER_HOUR:
-            return "m³/h"
+            return "m3"
         if self._Unit == ENERGY_KILO_WATT_HOUR:
             return "W"
         return None


### PR DESCRIPTION
## Summary

`ButtonCounter` counter channels can meter electricity, gas, or water, but the
only medium helper was `is_water()`. This adds `is_gas()` and `is_electricity()`
alongside it, and fixes `get_unit()` to return valid unit strings for the
instantaneous value.

## Changes

- Add `ButtonCounter.is_gas()` and `ButtonCounter.is_electricity()`, mirroring
  the existing `is_water()`, so consumers can classify a counter channel by its
  metered medium instead of matching on unit strings.
- `get_unit()` now returns the instantaneous-value units `L/h`, `m³/h`, `W`
  instead of `L`, `m3`, `W`. The gas/water values are flow rates, so a rate unit
  is correct, and `m³` is the proper character (the old `m3` is not a valid
  Home Assistant unit).

## Why

The Home Assistant `velbus` integration needs to know whether a counter channel
is electricity, gas, or water to pick the right `device_class`
(power/energy vs volume_flow_rate/gas/water). It currently has no clean way to
do that and `get_unit()` returned strings HA rejects. These helpers and the unit
fix let the integration classify channels by meaning.

## Related

Enables the Home Assistant core fix for gas/water counter channels on VMB7IN
(home-assistant/core issue #179361 — gas/water counters broke after the
counter power/energy split).